### PR TITLE
Migrate legacy slide decks to sld `slides.json` format

### DIFF
--- a/evaluationen/community-tools/slides.json
+++ b/evaluationen/community-tools/slides.json
@@ -1,0 +1,38 @@
+{
+  "tags": [
+    "groupware",
+    "community",
+    "evaluation",
+    "tools"
+  ],
+  "slides": [
+    {
+      "content": "slide1.md",
+      "audio": "slide1.txt"
+    },
+    {
+      "content": "slide2.md",
+      "audio": "slide2.txt"
+    },
+    {
+      "content": "login.md",
+      "audio": "login.txt"
+    },
+    {
+      "content": "räume.md",
+      "audio": "räume.txt"
+    },
+    {
+      "content": "slide3.md",
+      "audio": "slide3.txt"
+    },
+    {
+      "content": "tools.md",
+      "audio": "tools.txt"
+    },
+    {
+      "content": "features.md",
+      "audio": "features.txt"
+    }
+  ]
+}

--- a/explainations/javascript/grundlagen/slides.json
+++ b/explainations/javascript/grundlagen/slides.json
@@ -1,0 +1,58 @@
+{
+  "tags": [
+    "javascript",
+    "begriffe",
+    "konzepte",
+    "grundlagen"
+  ],
+  "slides": [
+    {
+      "content": "slide1.md",
+      "audio": "slide1.txt"
+    },
+    {
+      "content": "begriffsverwirrung.md",
+      "audio": "begriffsverwirrung.txt"
+    },
+    {
+      "content": "primitivetypen.md",
+      "audio": "primitivetypen.txt"
+    },
+    {
+      "content": "komplexetypen.md",
+      "audio": "komplexetypen.txt"
+    },
+    {
+      "content": "dynamictyping.md",
+      "audio": "dynamictyping.txt"
+    },
+    {
+      "content": "coercion.md",
+      "audio": "coercion.txt"
+    },
+    {
+      "content": "coerciontricks.md",
+      "audio": "coerciontricks.txt"
+    },
+    {
+      "content": "statischebindung.md",
+      "audio": "statischebindung.txt"
+    },
+    {
+      "content": "hoisting.md",
+      "audio": "hoisting.txt"
+    },
+    {
+      "content": "es6scope.md",
+      "audio": "es6scope.txt"
+    },
+    {
+      "content": "protractor.md",
+      "audio": "protractor.txt"
+    },
+    {
+      "content": "slide3.md",
+      "audio": "slide3.txt"
+    }
+  ]
+}

--- a/explainations/json/jsonschema/slides.json
+++ b/explainations/json/jsonschema/slides.json
@@ -1,0 +1,21 @@
+{
+  "tags": [
+    "json",
+    "schema",
+    "cdc"
+  ],
+  "slides": [
+    {
+      "content": "slide1.md",
+      "audio": "slide1.txt"
+    },
+    {
+      "content": "slide2.md",
+      "audio": "slide2.txt"
+    },
+    {
+      "content": "slide3.md",
+      "audio": "slide3.txt"
+    }
+  ]
+}

--- a/explainations/stenciljs/slides.json
+++ b/explainations/stenciljs/slides.json
@@ -1,0 +1,194 @@
+{
+  "tags": [
+    "stenciljs",
+    "begriffe",
+    "konzepte",
+    "grundlagen"
+  ],
+  "slides": [
+    {
+      "content": "titel.md",
+      "audio": "titel.txt"
+    },
+    {
+      "content": "author.md",
+      "audio": "author.txt"
+    },
+    {
+      "content": "erwartungen.md",
+      "audio": "erwartungen.txt"
+    },
+    {
+      "content": "spezifikationen.md",
+      "audio": "spezifikationen.txt"
+    },
+    {
+      "content": "domintegration.md",
+      "audio": "domintegration.txt"
+    },
+    {
+      "content": "slots.md",
+      "audio": "slots.txt"
+    },
+    {
+      "content": "frontendintegration.md",
+      "audio": "frontendintegration.txt"
+    },
+    {
+      "content": "entkopplung.md",
+      "audio": "entkopplung.txt"
+    },
+    {
+      "content": "vanillaexample.md",
+      "audio": "vanillaexample.txt"
+    },
+    {
+      "content": "stencil.md",
+      "audio": "stencil.txt"
+    },
+    {
+      "content": "lifecycle.md",
+      "audio": "lifecycle.txt"
+    },
+    {
+      "content": "stencilfeatures.md",
+      "audio": "stencilfeatures.txt"
+    },
+    {
+      "content": "virtualdom.md",
+      "audio": "virtualdom.txt"
+    },
+    {
+      "content": "hydratedapp.md",
+      "audio": "hydratedapp.txt"
+    },
+    {
+      "content": "funktionalekomponenten.md",
+      "audio": "funktionalekomponenten.txt"
+    },
+    {
+      "content": "einheitlichesdesign.md",
+      "audio": "einheitlichesdesign.txt"
+    },
+    {
+      "content": "dpleinbinden.md",
+      "audio": "dpleinbinden.txt"
+    },
+    {
+      "content": "cssvars.md",
+      "audio": "cssvars.txt"
+    },
+    {
+      "content": "supportcssvars.md",
+      "audio": "supportcssvars.txt"
+    },
+    {
+      "content": "supportcssrules.md",
+      "audio": "supportcssrules.txt"
+    },
+    {
+      "content": "webworker.md",
+      "audio": "webworker.txt"
+    },
+    {
+      "content": "dedicatedsharedworker.md",
+      "audio": "dedicatedsharedworker.txt"
+    },
+    {
+      "content": "serviceworker.md",
+      "audio": "serviceworker.txt"
+    },
+    {
+      "content": "featureswebworker.md",
+      "audio": "featureswebworker.txt"
+    },
+    {
+      "content": "dev-example.md",
+      "audio": "dev-example.txt"
+    },
+    {
+      "content": "dev-project.md",
+      "audio": "dev-project.txt"
+    },
+    {
+      "content": "dev-sources.md",
+      "audio": "dev-sources.txt"
+    },
+    {
+      "content": "dev-komponente.md",
+      "audio": "dev-komponente.txt"
+    },
+    {
+      "content": "dev-state.md",
+      "audio": "dev-state.txt"
+    },
+    {
+      "content": "dev-render.md",
+      "audio": "dev-render.txt"
+    },
+    {
+      "content": "dev-connected.md",
+      "audio": "dev-connected.txt"
+    },
+    {
+      "content": "dev-disconnected.md",
+      "audio": "dev-disconnected.txt"
+    },
+    {
+      "content": "dev-watcher.md",
+      "audio": "dev-watcher.txt"
+    },
+    {
+      "content": "dev-willload.md",
+      "audio": "dev-willload.txt"
+    },
+    {
+      "content": "dev-fetcher.md",
+      "audio": "dev-fetcher.txt"
+    },
+    {
+      "content": "dev-periodicfetcher.md",
+      "audio": "dev-periodicfetcher.txt"
+    },
+    {
+      "content": "dev-setter.md",
+      "audio": "dev-setter.txt"
+    },
+    {
+      "content": "dev-einbetten.md",
+      "audio": "dev-einbetten.txt"
+    },
+    {
+      "content": "dev-dom.md",
+      "audio": "dev-dom.txt"
+    },
+    {
+      "content": "dev-quellen.md",
+      "audio": "dev-quellen.txt"
+    },
+    {
+      "content": "danke.md",
+      "audio": "danke.txt"
+    },
+    {
+      "content": "setup.md",
+      "audio": "setup.txt"
+    },
+    {
+      "content": "states.md",
+      "audio": "states.txt"
+    },
+    {
+      "content": "ref.md",
+      "audio": "ref.txt"
+    },
+    {
+      "content": "bi-binding.md",
+      "audio": "bi-binding.txt"
+    },
+    {
+      "content": "quellen.md",
+      "audio": "quellen.txt"
+    }
+  ]
+}

--- a/explainations/test/unittest/slides.json
+++ b/explainations/test/unittest/slides.json
@@ -1,0 +1,20 @@
+{
+  "tags": [
+    "test",
+    "unitest"
+  ],
+  "slides": [
+    {
+      "content": "slide1.md",
+      "audio": "slide1.txt"
+    },
+    {
+      "content": "slide2.md",
+      "audio": "slide2.txt"
+    },
+    {
+      "content": "ende.md",
+      "audio": "ende.txt"
+    }
+  ]
+}

--- a/explainations/ux/designrules/slides.json
+++ b/explainations/ux/designrules/slides.json
@@ -1,0 +1,27 @@
+{
+  "tags": [
+    "ux",
+    "design",
+    "entscheidungen",
+    "gui",
+    "regeln"
+  ],
+  "slides": [
+    {
+      "content": "slide1.md",
+      "audio": "slide1.txt"
+    },
+    {
+      "content": "slide2.md",
+      "audio": "slide2.txt"
+    },
+    {
+      "content": "basisfragen.md",
+      "audio": "basisfragen.txt"
+    },
+    {
+      "content": "slide3.md",
+      "audio": "slide3.txt"
+    }
+  ]
+}

--- a/guides/bddtesting/slides.json
+++ b/guides/bddtesting/slides.json
@@ -1,0 +1,30 @@
+{
+  "tags": [
+    "bdd",
+    "cucumber",
+    "e2e",
+    "testing"
+  ],
+  "slides": [
+    {
+      "content": "slide1.md",
+      "audio": "slide1.txt"
+    },
+    {
+      "content": "slide2.md",
+      "audio": "slide2.txt"
+    },
+    {
+      "content": "slide3.md",
+      "audio": "slide3.txt"
+    },
+    {
+      "content": "slide4.md",
+      "audio": "slide4.txt"
+    },
+    {
+      "content": "slide5.md",
+      "audio": "slide5.txt"
+    }
+  ]
+}

--- a/guides/msys2-installation/slides.json
+++ b/guides/msys2-installation/slides.json
@@ -1,106 +1,46 @@
 {
-  "title": "MSYS2 - Installation und Einrichtung",
+  "tags": [
+    "msys2",
+    "howto",
+    "installation",
+    "configuration"
+  ],
   "slides": [
     {
-      "id": "1",
-      "title": "Willkommen",
       "content": "slide1.md",
-      "format": "md",
-      "audio": {
-        "type": "txt",
-        "src": "slide1.txt",
-        "lang": "de-DE",
-        "rate": 1.0,
-        "pitch": 1.0
-      }
+      "audio": "slide1.txt"
     },
     {
-      "id": "2",
-      "title": "Quellen",
       "content": "download.md",
-      "format": "md",
-      "audio": {
-        "type": "txt",
-        "src": "download.txt",
-        "lang": "de-DE"
-      }
+      "audio": "download.txt"
     },
     {
-      "id": "3",
-      "title": "Installation",
       "content": "installation.md",
-      "format": "md",
-      "audio": {
-        "type": "txt",
-        "src": "installation.txt",
-        "lang": "de-DE"
-      }
+      "audio": "installation.txt"
     },
     {
-      "id": "4",
-      "title": "Firmen Proxy",
       "content": "firmenproxy.md",
-      "format": "md",
-      "audio": {
-        "type": "txt",
-        "src": "firmenproxy.txt",
-        "lang": "de-DE"
-      }
+      "audio": "firmenproxy.txt"
     },
     {
-      "id": "5",
-      "title": "Update",
       "content": "update.md",
-      "format": "md",
-      "audio": {
-        "type": "txt",
-        "src": "update.txt",
-        "lang": "de-DE"
-      }
+      "audio": "update.txt"
     },
     {
-      "id": "6",
-      "title": "Home",
       "content": "home.md",
-      "format": "md",
-      "audio": {
-        "type": "txt",
-        "src": "home.txt",
-        "lang": "de-DE"
-      }
+      "audio": "home.txt"
     },
     {
-      "id": "7",
-      "title": "Winpath",
       "content": "winpath.md",
-      "format": "md",
-      "audio": {
-        "type": "txt",
-        "src": "winpath.txt",
-        "lang": "de-DE"
-      }
+      "audio": "winpath.txt"
     },
     {
-      "id": "8",
-      "title": "MSYS Path",
       "content": "msyspath.md",
-      "format": "md",
-      "audio": {
-        "type": "txt",
-        "src": "msyspath.txt",
-        "lang": "de-DE"
-      }
+      "audio": "msyspath.txt"
     },
     {
-      "id": "9",
-      "title": "Git",
       "content": "git.md",
-      "format": "md",
-      "audio": {
-        "type": "txt",
-        "src": "git.txt",
-        "lang": "de-DE"
-      }
+      "audio": "git.txt"
     }
   ]
 }

--- a/projects/foile-pile/slides.json
+++ b/projects/foile-pile/slides.json
@@ -1,0 +1,20 @@
+{
+  "tags": [
+    "foile",
+    "slides"
+  ],
+  "slides": [
+    {
+      "content": "slide1.md",
+      "audio": "slide1.txt"
+    },
+    {
+      "content": "slide2.md",
+      "audio": "slide2.txt"
+    },
+    {
+      "content": "slide3.md",
+      "audio": "slide3.txt"
+    }
+  ]
+}

--- a/projects/honey-slideshow/slides.json
+++ b/projects/honey-slideshow/slides.json
@@ -1,0 +1,22 @@
+{
+  "tags": [
+    "slideshow",
+    "slidecast",
+    "slides",
+    "audio"
+  ],
+  "slides": [
+    {
+      "content": "slide1.md",
+      "audio": "slide1.txt"
+    },
+    {
+      "content": "slide2.md",
+      "audio": "slide2.txt"
+    },
+    {
+      "content": "slide3.md",
+      "audio": "slide3.txt"
+    }
+  ]
+}

--- a/projects/jenkins-monitor/slides.json
+++ b/projects/jenkins-monitor/slides.json
@@ -1,0 +1,23 @@
+{
+  "tags": [
+    "jenkins",
+    "monitor",
+    "java",
+    "jenkinsmonitor",
+    "devops"
+  ],
+  "slides": [
+    {
+      "content": "slide1.md",
+      "audio": "slide1.txt"
+    },
+    {
+      "content": "slide2.md",
+      "audio": "slide2.txt"
+    },
+    {
+      "content": "slide3.md",
+      "audio": "slide3.txt"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Convert legacy slide decks that are still defined by `0index.txt` and/or `0tags.txt` into the new `sld` `slides.json` representation so the viewer/consumers use a single structured format. 
- Preserve slide order and tag metadata while being tolerant to legacy formatting (commas, wrapped lines, extra whitespace).

### Description
- Scanned the repository for directories containing `0index.txt` and/or `0tags.txt` and generated a `slides.json` in each detected directory; created `slides.json` for these directories: `evaluationen/community-tools`, `explainations/javascript/grundlagen`, `explainations/json/jsonschema`, `explainations/stenciljs`, `explainations/test/unittest`, `explainations/ux/designrules`, `guides/bddtesting`, `projects/foile-pile`, `projects/honey-slideshow`, and `projects/jenkins-monitor`.
- For each generated `slides.json` the `slides` array is produced from the prefixes listed in `0index.txt` where each entry maps to `{ "content": "<prefix>.md", "audio": "<prefix>.txt" }` and the `tags` key is populated from `0tags.txt` as an array of strings.
- Normalized the existing `guides/msys2-installation/slides.json` to the same migration schema by replacing nested `audio` objects and other legacy keys with the simplified `"audio": "..."` values and adding a `tags` array.
- JSON output is formatted with `ensure_ascii=false` and indentation for readability.

### Testing
- Located legacy markers using `rg --files | rg '(^|/)0(index|tags)\.txt$'`, which identified all target directories successfully.
- Verified that each generated `slides.json` is valid JSON by running `python -m json.tool` over the modified files, and validation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea6cff3e50832a983cf6a49df3b625)