### PR TITLE
Node-freier Entwickler- und Release-Workflow + CI-Checks

### DIFF
--- a/.github/workflows/docs-and-quickstart.yml
+++ b/.github/workflows/docs-and-quickstart.yml
@@ -1,0 +1,27 @@
+name: Docs & Quickstart
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+      - work
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Validate official docs are node-free
+        run: python3 scripts/validate_official_docs.py
+
+      - name: Run quickstart smoke test
+        run: bash scripts/check_quickstart.sh

--- a/.github/workflows/release-static-site.yml
+++ b/.github/workflows/release-static-site.yml
@@ -1,0 +1,31 @@
+name: Release Static Site Bundle
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  bundle:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build static bundle
+        run: |
+          mkdir -p dist
+          tar \
+            --exclude='./.git' \
+            --exclude='./dist' \
+            -czf "dist/foile-pile-${GITHUB_REF_NAME}.tar.gz" \
+            .
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/foile-pile-${{ github.ref_name }}.tar.gz
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # foile-pile
 
-An Portal zur Ablage von Präsentationen.
+Ein Portal zur Ablage von Präsentationen.
+
+## Entwickler-Quickstart (ohne Node.js)
+
+```bash
+git clone https://github.com/Huluvu424242/foile-pile.git
+cd foile-pile
+bash scripts/check_quickstart.sh
+```
+
+Weitere Details zu Setup, Checks und Release-Prozess sind in [`docs/developer-workflow.md`](docs/developer-workflow.md) dokumentiert.

--- a/docs/developer-workflow.md
+++ b/docs/developer-workflow.md
@@ -1,0 +1,58 @@
+# Entwickler-Workflow ohne Node.js
+
+Diese Anleitung beschreibt den offiziellen Setup- und Release-Weg für dieses Repository ohne npm-Tooling.
+
+## Voraussetzungen
+
+- Git
+- Bash (Linux/macOS oder Git Bash unter Windows)
+- Python 3.10+
+- `curl` (für den lokalen Smoke-Test)
+
+## Quickstart (sauberes System)
+
+```bash
+git clone https://github.com/Huluvu424242/foile-pile.git
+cd foile-pile
+python3 --version
+bash scripts/check_quickstart.sh
+```
+
+Ergebnis: Das Script startet lokal einen Webserver, prüft die Erreichbarkeit von `projects/foile-pile/index.html` und beendet sich danach wieder.
+
+## Lokale Dokumentations- und Workflow-Checks
+
+```bash
+python3 scripts/validate_official_docs.py
+bash scripts/check_quickstart.sh
+```
+
+## GitHub Actions Workflows
+
+### 1) Docs & Quickstart
+Datei: `.github/workflows/docs-and-quickstart.yml`
+
+- Läuft bei Push und Pull Request.
+- Prüft, dass die offizielle Doku keine Node-/npm-Kommandos enthält.
+- Führt den Quickstart-Smoke-Test mit Python/Bash aus.
+
+### 2) Release Static Site Bundle
+Datei: `.github/workflows/release-static-site.yml`
+
+- Läuft bei Tag-Push `v*` (z. B. `v1.0.0`).
+- Erstellt ein statisches Tarball-Artefakt des Repositories.
+- Veröffentlicht das Bundle als GitHub Release Asset.
+
+## Release-Ablauf
+
+```bash
+# optional: lokale Checks
+python3 scripts/validate_official_docs.py
+bash scripts/check_quickstart.sh
+
+# Release-Tag erstellen
+git tag v1.0.0
+git push origin v1.0.0
+```
+
+Nach dem Tag-Push erstellt GitHub Actions automatisch einen Release-Eintrag mit dem statischen Bundle.

--- a/scripts/check_quickstart.sh
+++ b/scripts/check_quickstart.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PORT="${QUICKSTART_PORT:-8015}"
+
+if [[ ! -f "$ROOT_DIR/projects/foile-pile/index.html" ]]; then
+  echo "Expected entrypoint projects/foile-pile/index.html not found" >&2
+  exit 1
+fi
+
+python3 -m http.server "$PORT" --directory "$ROOT_DIR" >/tmp/foile-pile-http.log 2>&1 &
+SERVER_PID=$!
+
+cleanup() {
+  if kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+for _ in {1..20}; do
+  if curl -fsS "http://127.0.0.1:${PORT}/projects/foile-pile/index.html" >/dev/null; then
+    echo "Quickstart smoke test passed (served projects/foile-pile/index.html)."
+    exit 0
+  fi
+  sleep 0.5
+done
+
+echo "Quickstart smoke test failed; http.server did not become reachable in time." >&2
+if [[ -f /tmp/foile-pile-http.log ]]; then
+  echo "--- http.server log ---" >&2
+  cat /tmp/foile-pile-http.log >&2
+fi
+exit 1

--- a/scripts/validate_official_docs.py
+++ b/scripts/validate_official_docs.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Validate that official docs do not reference Node.js/npm commands."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+OFFICIAL_DOCS = [
+    ROOT / "README.md",
+    ROOT / "docs" / "developer-workflow.md",
+]
+
+# block standalone node/npm terms and typical command patterns
+BLOCKED_PATTERNS = [
+    re.compile(r"(?i)\\bnpm\\b"),
+    re.compile(r"(?i)\\bnode(\\.js)?\\b"),
+    re.compile(r"(?i)\\bnpx\\b"),
+    re.compile(r"(?i)\\byarn\\b"),
+    re.compile(r"(?i)\\bpnpm\\b"),
+]
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    for doc_path in OFFICIAL_DOCS:
+        if not doc_path.exists():
+            failures.append(f"Missing required documentation file: {doc_path.relative_to(ROOT)}")
+            continue
+
+        text = doc_path.read_text(encoding="utf-8")
+        for idx, line in enumerate(text.splitlines(), start=1):
+            for pattern in BLOCKED_PATTERNS:
+                if pattern.search(line):
+                    failures.append(
+                        f"{doc_path.relative_to(ROOT)}:{idx}: blocked token found -> {line.strip()}"
+                    )
+                    break
+
+    if failures:
+        print("Documentation validation failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+
+    print("Documentation validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Das Repository soll ohne Node.js/npm betreib- und veröffentlichbar sein und automatisierte Checks für die offizielle Dokumentation und den Quickstart erhalten.
- Ein reproduzierbarer, leicht prüfbarer Release-Prozess für statische Artefakte soll per Tag-Push möglich sein.

### Description
- Ergänzt `docs/developer-workflow.md` und erweitert `README.md` um einen Node-freien Quickstart und Verweis auf die detaillierte Doku. 
- Fügt zwei GitHub Actions Workflows hinzu: `docs-and-quickstart.yml` (Push/PR) für Doku-Validierung und Quickstart-Smoke-Test und `release-static-site.yml` (Tag `v*`) für das Erstellen und Veröffentlichen eines statischen Tarball-Releases. 
- Legt unterstützende Skripte in `scripts/` an: `scripts/validate_official_docs.py` prüft auf node/npm-bezogene Tokens in offiziellen Docs und `scripts/check_quickstart.sh` startet einen lokalen `python3 -m http.server` und validiert Erreichbarkeit von `projects/foile-pile/index.html`. 
- Stellt Dateiberechtigungen/Exekutabilität für die Shell-/Python-Skripte sicher und dokumentiert die lokalen Arbeitsabläufe und Release-Schritte in `docs/`.

### Testing
- Lokaler Dokumentationscheck mit `python3 scripts/validate_official_docs.py` wurde ausgeführt und hat bestanden. 
- Lokaler Quickstart-Smoke-Test mit `bash scripts/check_quickstart.sh` wurde ausgeführt und hat bestanden. 
- CI-Workflows sind ergänzt und werden bei Push/PR bzw. Tag-Push die gleichen Checks bzw. das Release-Build ausführen (Ergebnis in GitHub Actions nach Ausführung).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea7403a5c4832ab7ec31ccc0e5a54b)