### PR TITLE
Standardisierte Präsentationsstruktur und Validierung hinzufügen

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,8 @@ Als Nutzer möchte ich in einem Webportal Präsentationen finden, ansehen und al
 - Sehr große Präsentationen können clientseitiges ZIP-Bauen verlangsamen → progress indicator + Web Worker einplanen.
 - CORS/Path-Probleme bei nicht standardisiertem Hosting vermeiden (nur relative Pfade, keine absoluten host-spezifischen URLs).
 - Frühzeitiger Vertragstest mit `sld-slideshow-viewer` reduziert Integrationsrisiko.
+
+## Repository-Konventionen
+- Standardisierte Präsentationsstruktur: `docs/presentation-structure.md`
+- Validierungsskript: `python scripts/validate_repository_structure.py`
+

--- a/docs/presentation-structure.md
+++ b/docs/presentation-structure.md
@@ -1,0 +1,57 @@
+# Repository-Struktur für Präsentationen
+
+Dieses Repository verwendet ein einheitliches Schema, damit Suche, Viewer und Download automatisiert arbeiten können.
+
+## Verzeichnis-Schema
+
+Alle Präsentationen liegen nach folgendem Muster:
+
+`/<bereich>/<thema>/<praesentation>/`
+
+Im aktuellen Bestand werden dafür folgende Bereichsordner verwendet:
+
+- `guides/`
+- `explainations/`
+- `evaluationen/`
+- `projects/`
+
+Eine Präsentation wird technisch darüber erkannt, dass im Präsentationsordner eine `slides.json` vorhanden ist.
+
+## Pflichtdateien pro Präsentation
+
+Jeder Präsentationsordner muss mindestens enthalten:
+
+- `slides.json`
+- `manifest.json`
+
+## Pflichtmetadaten (`manifest.json`)
+
+`manifest.json` muss ein JSON-Objekt mit folgenden Feldern sein:
+
+- `title` (String): Anzeigename der Präsentation
+- `language` (String): Sprachkürzel, z. B. `de` oder `en`
+- `tags` (Array[String]): Such- und Filterbegriffe
+- `description` (String): Kurzbeschreibung der Präsentation
+- `path` (String): Relativer Pfad des Präsentationsordners ab Repository-Root
+
+Beispiel:
+
+```json
+{
+  "title": "Grundlagen",
+  "language": "de",
+  "tags": ["javascript", "types"],
+  "description": "Einführung in JavaScript-Grundlagen.",
+  "path": "explainations/javascript/grundlagen"
+}
+```
+
+## Validierung
+
+Die Struktur und Pflichtmetadaten können mit folgendem Skript geprüft werden:
+
+```bash
+python scripts/validate_repository_structure.py
+```
+
+Bei Verstößen gibt das Skript verständliche Fehler inkl. Dateipfad aus und beendet sich mit Exit-Code `1`.

--- a/evaluationen/community-tools/manifest.json
+++ b/evaluationen/community-tools/manifest.json
@@ -1,0 +1,12 @@
+{
+  "title": "Community Tools",
+  "language": "de",
+  "tags": [
+    "groupware",
+    "community",
+    "evaluation",
+    "tools"
+  ],
+  "description": "Präsentation im Bereich \"evaluationen\" zum Thema \"Community Tools\".",
+  "path": "evaluationen/community-tools"
+}

--- a/explainations/javascript/grundlagen/manifest.json
+++ b/explainations/javascript/grundlagen/manifest.json
@@ -1,0 +1,12 @@
+{
+  "title": "Grundlagen",
+  "language": "de",
+  "tags": [
+    "javascript",
+    "begriffe",
+    "konzepte",
+    "grundlagen"
+  ],
+  "description": "Präsentation im Bereich \"explainations\" zum Thema \"Grundlagen\".",
+  "path": "explainations/javascript/grundlagen"
+}

--- a/explainations/json/jsonschema/manifest.json
+++ b/explainations/json/jsonschema/manifest.json
@@ -1,0 +1,11 @@
+{
+  "title": "Jsonschema",
+  "language": "de",
+  "tags": [
+    "json",
+    "schema",
+    "cdc"
+  ],
+  "description": "Präsentation im Bereich \"explainations\" zum Thema \"Jsonschema\".",
+  "path": "explainations/json/jsonschema"
+}

--- a/explainations/mesh/meshnetze/manifest.json
+++ b/explainations/mesh/meshnetze/manifest.json
@@ -1,0 +1,12 @@
+{
+  "title": "Meshnetze",
+  "language": "de",
+  "tags": [
+    "slideshow",
+    "mesh netze",
+    "mesh",
+    "grundlagen"
+  ],
+  "description": "Präsentation im Bereich \"explainations\" zum Thema \"Meshnetze\".",
+  "path": "explainations/mesh/meshnetze"
+}

--- a/explainations/stenciljs/manifest.json
+++ b/explainations/stenciljs/manifest.json
@@ -1,0 +1,12 @@
+{
+  "title": "Stenciljs",
+  "language": "de",
+  "tags": [
+    "stenciljs",
+    "begriffe",
+    "konzepte",
+    "grundlagen"
+  ],
+  "description": "Präsentation im Bereich \"explainations\" zum Thema \"Stenciljs\".",
+  "path": "explainations/stenciljs"
+}

--- a/explainations/test/unittest/manifest.json
+++ b/explainations/test/unittest/manifest.json
@@ -1,0 +1,10 @@
+{
+  "title": "Unittest",
+  "language": "de",
+  "tags": [
+    "test",
+    "unitest"
+  ],
+  "description": "Präsentation im Bereich \"explainations\" zum Thema \"Unittest\".",
+  "path": "explainations/test/unittest"
+}

--- a/explainations/ux/designrules/manifest.json
+++ b/explainations/ux/designrules/manifest.json
@@ -1,0 +1,13 @@
+{
+  "title": "Designrules",
+  "language": "de",
+  "tags": [
+    "ux",
+    "design",
+    "entscheidungen",
+    "gui",
+    "regeln"
+  ],
+  "description": "Präsentation im Bereich \"explainations\" zum Thema \"Designrules\".",
+  "path": "explainations/ux/designrules"
+}

--- a/guides/bddtesting/manifest.json
+++ b/guides/bddtesting/manifest.json
@@ -1,0 +1,12 @@
+{
+  "title": "Bddtesting",
+  "language": "de",
+  "tags": [
+    "bdd",
+    "cucumber",
+    "e2e",
+    "testing"
+  ],
+  "description": "Präsentation im Bereich \"guides\" zum Thema \"Bddtesting\".",
+  "path": "guides/bddtesting"
+}

--- a/guides/msys2-installation/manifest.json
+++ b/guides/msys2-installation/manifest.json
@@ -1,0 +1,12 @@
+{
+  "title": "Msys2 Installation",
+  "language": "de",
+  "tags": [
+    "msys2",
+    "howto",
+    "installation",
+    "configuration"
+  ],
+  "description": "Präsentation im Bereich \"guides\" zum Thema \"Msys2 Installation\".",
+  "path": "guides/msys2-installation"
+}

--- a/projects/foile-pile/manifest.json
+++ b/projects/foile-pile/manifest.json
@@ -1,0 +1,10 @@
+{
+  "title": "Foile Pile",
+  "language": "de",
+  "tags": [
+    "foile",
+    "slides"
+  ],
+  "description": "Präsentation im Bereich \"projects\" zum Thema \"Foile Pile\".",
+  "path": "projects/foile-pile"
+}

--- a/projects/honey-slideshow/manifest.json
+++ b/projects/honey-slideshow/manifest.json
@@ -1,0 +1,12 @@
+{
+  "title": "Honey Slideshow",
+  "language": "de",
+  "tags": [
+    "slideshow",
+    "slidecast",
+    "slides",
+    "audio"
+  ],
+  "description": "Präsentation im Bereich \"projects\" zum Thema \"Honey Slideshow\".",
+  "path": "projects/honey-slideshow"
+}

--- a/projects/jenkins-monitor/manifest.json
+++ b/projects/jenkins-monitor/manifest.json
@@ -1,0 +1,13 @@
+{
+  "title": "Jenkins Monitor",
+  "language": "de",
+  "tags": [
+    "jenkins",
+    "monitor",
+    "java",
+    "jenkinsmonitor",
+    "devops"
+  ],
+  "description": "Präsentation im Bereich \"projects\" zum Thema \"Jenkins Monitor\".",
+  "path": "projects/jenkins-monitor"
+}

--- a/scripts/validate_repository_structure.py
+++ b/scripts/validate_repository_structure.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Validiert die standardisierte Präsentationsstruktur im Repository."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REQUIRED_FIELDS = {
+    "title": str,
+    "language": str,
+    "tags": list,
+    "description": str,
+    "path": str,
+}
+
+
+def is_non_empty_string(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def validate_manifest(manifest_path: Path, repo_root: Path) -> list[str]:
+    errors: list[str] = []
+
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [f"{manifest_path}: Ungültiges JSON ({exc})"]
+
+    if not isinstance(data, dict):
+        return [f"{manifest_path}: manifest.json muss ein JSON-Objekt sein."]
+
+    for field, expected_type in REQUIRED_FIELDS.items():
+        if field not in data:
+            errors.append(f"{manifest_path}: Pflichtfeld '{field}' fehlt.")
+            continue
+
+        value = data[field]
+        if not isinstance(value, expected_type):
+            errors.append(
+                f"{manifest_path}: Feld '{field}' muss vom Typ "
+                f"{expected_type.__name__} sein."
+            )
+
+    for field in ("title", "language", "description", "path"):
+        if field in data and not is_non_empty_string(data[field]):
+            errors.append(f"{manifest_path}: Feld '{field}' darf nicht leer sein.")
+
+    if "tags" in data:
+        tags = data["tags"]
+        if not isinstance(tags, list) or not all(is_non_empty_string(tag) for tag in tags):
+            errors.append(
+                f"{manifest_path}: Feld 'tags' muss ein Array nicht-leerer Strings sein."
+            )
+
+    if "path" in data and isinstance(data["path"], str):
+        actual_path = manifest_path.parent.relative_to(repo_root).as_posix()
+        if data["path"] != actual_path:
+            errors.append(
+                f"{manifest_path}: Feld 'path' ist '{data['path']}', erwartet '{actual_path}'."
+            )
+
+    return errors
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    slide_files = sorted(repo_root.glob("**/slides.json"))
+
+    errors: list[str] = []
+
+    if not slide_files:
+        print("WARNUNG: Keine slides.json gefunden.")
+        return 0
+
+    for slides_file in slide_files:
+        presentation_dir = slides_file.parent
+        manifest_path = presentation_dir / "manifest.json"
+
+        if not manifest_path.exists():
+            errors.append(f"{presentation_dir}: manifest.json fehlt.")
+            continue
+
+        errors.extend(validate_manifest(manifest_path, repo_root))
+
+    if errors:
+        print("Strukturprüfung fehlgeschlagen:\n")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print(f"OK: {len(slide_files)} Präsentationen erfolgreich validiert.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Repositoryweit eine einheitliche Struktur und Pflichtmetadaten für Präsentationen bereitstellen, damit Viewer, Suche und ZIP-Download automatisiert arbeiten können.
- Sicherstellen, dass bestehende Präsentationen die neuen Metadaten (`manifest.json`) enthalten und maschinell überprüfbar sind.
- Frühe Validierung verhindert Inkonsistenzen bei Pfaden, fehlenden Feldern und fehlerhaftem JSON.

### Description
- Dokumentation der Konventionen in `docs/presentation-structure.md` ergänzt, inklusive Beispiel und Validierungsaufruf.
- Root-`README.md` um einen Verweis auf die Struktur-Doku und das Validierungsskript erweitert.
- Für bestehende Präsentationen wurden `manifest.json`-Dateien mit den Pflichtfeldern `title`, `language`, `tags`, `description` und `path` angelegt (bestehende Inhalte angepasst, insgesamt 12 Präsentationen). 
- Validierungsskript `scripts/validate_repository_structure.py` hinzugefügt, das alle `slides.json` findet, das Vorhandensein von `manifest.json` prüft, Feldtypen und Nicht-Leer-Werte validiert und sicherstellt, dass `path` dem tatsächlichen Ordnerpfad entspricht.

### Testing
- `python scripts/validate_repository_structure.py` wurde ausgeführt und lieferte `OK: 12 Präsentationen erfolgreich validiert.` (Exit-Code `0`).
- `python -m py_compile scripts/validate_repository_structure.py` wurde ausgeführt und zeigte keine Syntaxfehler.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea76159cb8832a98a9ff64029a87b7)