### PR TITLE
Add reproducible central search index generation and CI validation

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -1,0 +1,25 @@
+name: Repository Checks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Validate repository structure
+        run: python scripts/validate_repository_structure.py
+
+      - name: Validate central search index
+        run: python scripts/check_search_index.py

--- a/README.md
+++ b/README.md
@@ -27,3 +27,6 @@ Als Nutzer möchte ich in einem Webportal Präsentationen finden, ansehen und al
 - Standardisierte Präsentationsstruktur: `docs/presentation-structure.md`
 - Validierungsskript: `python scripts/validate_repository_structure.py`
 
+- Zentralen Suchindex erzeugen: `python scripts/generate_search_index.py`
+- Suchindex auf Aktualität prüfen: `python scripts/check_search_index.py`
+

--- a/docs/presentation-structure.md
+++ b/docs/presentation-structure.md
@@ -55,3 +55,31 @@ python scripts/validate_repository_structure.py
 ```
 
 Bei Verstößen gibt das Skript verständliche Fehler inkl. Dateipfad aus und beendet sich mit Exit-Code `1`.
+
+
+## Zentraler Suchindex (`index.json`)
+
+Im Repository-Root wird ein zentraler Suchindex mit versioniertem Schema gepflegt:
+
+- Datei: `index.json`
+- Feld `schemaVersion`: aktuelle Schema-Version des Indexformats
+- Feld `presentations`: Liste aller Präsentationen inkl. Suchfelder und Dateireferenzen
+
+Pro Eintrag werden u. a. diese Informationen bereitgestellt:
+
+- `title`, `description`, `language`, `tags`, `path`
+- `searchText` (voraggregierter Suchtext für clientseitige Suche)
+- `slideCount`
+- `files` mit Referenzen auf `manifest.json`, `slides.json`, `index.html`, `0tags.txt`, `0index.txt`
+
+Erzeugung (reproduzierbar, ohne Node.js):
+
+```bash
+python scripts/generate_search_index.py
+```
+
+Aktualitätsprüfung (lokal/CI):
+
+```bash
+python scripts/check_search_index.py
+```

--- a/index.json
+++ b/index.json
@@ -1,0 +1,254 @@
+{
+  "presentations": [
+    {
+      "description": "Präsentation im Bereich \"evaluationen\" zum Thema \"Community Tools\".",
+      "files": {
+        "fulltext": "evaluationen/community-tools/0index.txt",
+        "manifest": "evaluationen/community-tools/manifest.json",
+        "slides": "evaluationen/community-tools/slides.json",
+        "tags": "evaluationen/community-tools/0tags.txt",
+        "viewer": "evaluationen/community-tools/index.html"
+      },
+      "language": "de",
+      "path": "evaluationen/community-tools",
+      "searchText": "Community Tools Präsentation im Bereich \"evaluationen\" zum Thema \"Community Tools\". groupware community evaluation tools de",
+      "slideCount": 7,
+      "tags": [
+        "groupware",
+        "community",
+        "evaluation",
+        "tools"
+      ],
+      "title": "Community Tools"
+    },
+    {
+      "description": "Präsentation im Bereich \"explainations\" zum Thema \"Grundlagen\".",
+      "files": {
+        "fulltext": "explainations/javascript/grundlagen/0index.txt",
+        "manifest": "explainations/javascript/grundlagen/manifest.json",
+        "slides": "explainations/javascript/grundlagen/slides.json",
+        "tags": "explainations/javascript/grundlagen/0tags.txt",
+        "viewer": "explainations/javascript/grundlagen/index.html"
+      },
+      "language": "de",
+      "path": "explainations/javascript/grundlagen",
+      "searchText": "Grundlagen Präsentation im Bereich \"explainations\" zum Thema \"Grundlagen\". javascript begriffe konzepte grundlagen de",
+      "slideCount": 12,
+      "tags": [
+        "javascript",
+        "begriffe",
+        "konzepte",
+        "grundlagen"
+      ],
+      "title": "Grundlagen"
+    },
+    {
+      "description": "Präsentation im Bereich \"explainations\" zum Thema \"Jsonschema\".",
+      "files": {
+        "fulltext": "explainations/json/jsonschema/0index.txt",
+        "manifest": "explainations/json/jsonschema/manifest.json",
+        "slides": "explainations/json/jsonschema/slides.json",
+        "tags": "explainations/json/jsonschema/0tags.txt",
+        "viewer": "explainations/json/jsonschema/index.html"
+      },
+      "language": "de",
+      "path": "explainations/json/jsonschema",
+      "searchText": "Jsonschema Präsentation im Bereich \"explainations\" zum Thema \"Jsonschema\". json schema cdc de",
+      "slideCount": 3,
+      "tags": [
+        "json",
+        "schema",
+        "cdc"
+      ],
+      "title": "Jsonschema"
+    },
+    {
+      "description": "Präsentation im Bereich \"explainations\" zum Thema \"Meshnetze\".",
+      "files": {
+        "fulltext": "explainations/mesh/meshnetze/0index.txt",
+        "manifest": "explainations/mesh/meshnetze/manifest.json",
+        "slides": "explainations/mesh/meshnetze/slides.json",
+        "tags": "explainations/mesh/meshnetze/0tags.txt",
+        "viewer": "explainations/mesh/meshnetze/index.html"
+      },
+      "language": "de",
+      "path": "explainations/mesh/meshnetze",
+      "searchText": "Meshnetze Präsentation im Bereich \"explainations\" zum Thema \"Meshnetze\". slideshow mesh netze mesh grundlagen de",
+      "slideCount": 11,
+      "tags": [
+        "slideshow",
+        "mesh netze",
+        "mesh",
+        "grundlagen"
+      ],
+      "title": "Meshnetze"
+    },
+    {
+      "description": "Präsentation im Bereich \"explainations\" zum Thema \"Stenciljs\".",
+      "files": {
+        "fulltext": "explainations/stenciljs/0index.txt",
+        "manifest": "explainations/stenciljs/manifest.json",
+        "slides": "explainations/stenciljs/slides.json",
+        "tags": "explainations/stenciljs/0tags.txt",
+        "viewer": "explainations/stenciljs/index.html"
+      },
+      "language": "de",
+      "path": "explainations/stenciljs",
+      "searchText": "Stenciljs Präsentation im Bereich \"explainations\" zum Thema \"Stenciljs\". stenciljs begriffe konzepte grundlagen de",
+      "slideCount": 46,
+      "tags": [
+        "stenciljs",
+        "begriffe",
+        "konzepte",
+        "grundlagen"
+      ],
+      "title": "Stenciljs"
+    },
+    {
+      "description": "Präsentation im Bereich \"explainations\" zum Thema \"Unittest\".",
+      "files": {
+        "fulltext": "explainations/test/unittest/0index.txt",
+        "manifest": "explainations/test/unittest/manifest.json",
+        "slides": "explainations/test/unittest/slides.json",
+        "tags": "explainations/test/unittest/0tags.txt",
+        "viewer": "explainations/test/unittest/index.html"
+      },
+      "language": "de",
+      "path": "explainations/test/unittest",
+      "searchText": "Unittest Präsentation im Bereich \"explainations\" zum Thema \"Unittest\". test unitest de",
+      "slideCount": 3,
+      "tags": [
+        "test",
+        "unitest"
+      ],
+      "title": "Unittest"
+    },
+    {
+      "description": "Präsentation im Bereich \"explainations\" zum Thema \"Designrules\".",
+      "files": {
+        "fulltext": "explainations/ux/designrules/0index.txt",
+        "manifest": "explainations/ux/designrules/manifest.json",
+        "slides": "explainations/ux/designrules/slides.json",
+        "tags": "explainations/ux/designrules/0tags.txt",
+        "viewer": "explainations/ux/designrules/index.html"
+      },
+      "language": "de",
+      "path": "explainations/ux/designrules",
+      "searchText": "Designrules Präsentation im Bereich \"explainations\" zum Thema \"Designrules\". ux design entscheidungen gui regeln de",
+      "slideCount": 4,
+      "tags": [
+        "ux",
+        "design",
+        "entscheidungen",
+        "gui",
+        "regeln"
+      ],
+      "title": "Designrules"
+    },
+    {
+      "description": "Präsentation im Bereich \"guides\" zum Thema \"Bddtesting\".",
+      "files": {
+        "fulltext": "guides/bddtesting/0index.txt",
+        "manifest": "guides/bddtesting/manifest.json",
+        "slides": "guides/bddtesting/slides.json",
+        "tags": "guides/bddtesting/0tags.txt",
+        "viewer": "guides/bddtesting/index.html"
+      },
+      "language": "de",
+      "path": "guides/bddtesting",
+      "searchText": "Bddtesting Präsentation im Bereich \"guides\" zum Thema \"Bddtesting\". bdd cucumber e2e testing de",
+      "slideCount": 5,
+      "tags": [
+        "bdd",
+        "cucumber",
+        "e2e",
+        "testing"
+      ],
+      "title": "Bddtesting"
+    },
+    {
+      "description": "Präsentation im Bereich \"guides\" zum Thema \"Msys2 Installation\".",
+      "files": {
+        "fulltext": "guides/msys2-installation/0index.txt",
+        "manifest": "guides/msys2-installation/manifest.json",
+        "slides": "guides/msys2-installation/slides.json",
+        "tags": "guides/msys2-installation/0tags.txt",
+        "viewer": "guides/msys2-installation/index.html"
+      },
+      "language": "de",
+      "path": "guides/msys2-installation",
+      "searchText": "Msys2 Installation Präsentation im Bereich \"guides\" zum Thema \"Msys2 Installation\". msys2 howto installation configuration de",
+      "slideCount": 9,
+      "tags": [
+        "msys2",
+        "howto",
+        "installation",
+        "configuration"
+      ],
+      "title": "Msys2 Installation"
+    },
+    {
+      "description": "Präsentation im Bereich \"projects\" zum Thema \"Foile Pile\".",
+      "files": {
+        "fulltext": "projects/foile-pile/0index.txt",
+        "manifest": "projects/foile-pile/manifest.json",
+        "slides": "projects/foile-pile/slides.json",
+        "tags": "projects/foile-pile/0tags.txt",
+        "viewer": "projects/foile-pile/index.html"
+      },
+      "language": "de",
+      "path": "projects/foile-pile",
+      "searchText": "Foile Pile Präsentation im Bereich \"projects\" zum Thema \"Foile Pile\". foile slides de",
+      "slideCount": 3,
+      "tags": [
+        "foile",
+        "slides"
+      ],
+      "title": "Foile Pile"
+    },
+    {
+      "description": "Präsentation im Bereich \"projects\" zum Thema \"Honey Slideshow\".",
+      "files": {
+        "fulltext": "projects/honey-slideshow/0index.txt",
+        "manifest": "projects/honey-slideshow/manifest.json",
+        "slides": "projects/honey-slideshow/slides.json",
+        "tags": "projects/honey-slideshow/0tags.txt",
+        "viewer": "projects/honey-slideshow/index.html"
+      },
+      "language": "de",
+      "path": "projects/honey-slideshow",
+      "searchText": "Honey Slideshow Präsentation im Bereich \"projects\" zum Thema \"Honey Slideshow\". slideshow slidecast slides audio de",
+      "slideCount": 3,
+      "tags": [
+        "slideshow",
+        "slidecast",
+        "slides",
+        "audio"
+      ],
+      "title": "Honey Slideshow"
+    },
+    {
+      "description": "Präsentation im Bereich \"projects\" zum Thema \"Jenkins Monitor\".",
+      "files": {
+        "fulltext": "projects/jenkins-monitor/0index.txt",
+        "manifest": "projects/jenkins-monitor/manifest.json",
+        "slides": "projects/jenkins-monitor/slides.json",
+        "tags": "projects/jenkins-monitor/0tags.txt",
+        "viewer": "projects/jenkins-monitor/index.html"
+      },
+      "language": "de",
+      "path": "projects/jenkins-monitor",
+      "searchText": "Jenkins Monitor Präsentation im Bereich \"projects\" zum Thema \"Jenkins Monitor\". jenkins monitor java jenkinsmonitor devops de",
+      "slideCount": 3,
+      "tags": [
+        "jenkins",
+        "monitor",
+        "java",
+        "jenkinsmonitor",
+        "devops"
+      ],
+      "title": "Jenkins Monitor"
+    }
+  ],
+  "schemaVersion": "1.0.0"
+}

--- a/scripts/check_search_index.py
+++ b/scripts/check_search_index.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Prüft, ob index.json dem aktuell generierten Suchindex entspricht."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+from generate_search_index import build_index, write_index
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    committed_index = repo_root / "index.json"
+
+    if not committed_index.exists():
+        print("FEHLER: index.json fehlt. Bitte zuerst generieren.")
+        return 1
+
+    expected_data = build_index(repo_root)
+
+    with tempfile.TemporaryDirectory(prefix="foile-pile-index-check-") as tmpdir:
+        generated_path = Path(tmpdir) / "index.json"
+        write_index(expected_data, generated_path)
+
+        committed = json.loads(committed_index.read_text(encoding="utf-8"))
+        generated = json.loads(generated_path.read_text(encoding="utf-8"))
+
+    if committed != generated:
+        print("FEHLER: index.json ist nicht aktuell.")
+        print("Bitte ausführen: python scripts/generate_search_index.py")
+        return 1
+
+    print("OK: index.json ist aktuell.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_search_index.py
+++ b/scripts/generate_search_index.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Erzeugt den zentralen, statisch auslieferbaren Suchindex (index.json)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SCHEMA_VERSION = "1.0.0"
+
+
+def load_json(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def discover_presentations(repo_root: Path) -> list[dict[str, object]]:
+    presentations: list[dict[str, object]] = []
+
+    for slides_path in sorted(repo_root.glob("**/slides.json")):
+        presentation_dir = slides_path.parent
+        manifest_path = presentation_dir / "manifest.json"
+
+        if not manifest_path.exists():
+            raise FileNotFoundError(f"{manifest_path} fehlt.")
+
+        manifest = load_json(manifest_path)
+        slides = load_json(slides_path)
+
+        if not isinstance(manifest, dict):
+            raise ValueError(f"{manifest_path} muss ein JSON-Objekt sein.")
+        if not isinstance(slides, dict):
+            raise ValueError(f"{slides_path} muss ein JSON-Objekt sein.")
+
+        rel_path = presentation_dir.relative_to(repo_root).as_posix()
+        slide_entries = slides.get("slides", [])
+        slide_count = len(slide_entries) if isinstance(slide_entries, list) else 0
+
+        files = {
+            "manifest": manifest_path.relative_to(repo_root).as_posix(),
+            "slides": slides_path.relative_to(repo_root).as_posix(),
+            "viewer": f"{rel_path}/index.html",
+            "tags": f"{rel_path}/0tags.txt",
+            "fulltext": f"{rel_path}/0index.txt",
+        }
+
+        search_text = " ".join(
+            str(value)
+            for value in (
+                manifest.get("title", ""),
+                manifest.get("description", ""),
+                " ".join(manifest.get("tags", [])) if isinstance(manifest.get("tags"), list) else "",
+                manifest.get("language", ""),
+            )
+            if isinstance(value, str)
+        ).strip()
+
+        presentations.append(
+            {
+                "title": manifest.get("title", ""),
+                "description": manifest.get("description", ""),
+                "language": manifest.get("language", ""),
+                "tags": manifest.get("tags", []),
+                "path": rel_path,
+                "slideCount": slide_count,
+                "searchText": search_text,
+                "files": files,
+            }
+        )
+
+    return sorted(presentations, key=lambda item: str(item["path"]))
+
+
+def build_index(repo_root: Path) -> dict[str, object]:
+    presentations = discover_presentations(repo_root)
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "presentations": presentations,
+    }
+
+
+def write_index(index_data: dict[str, object], target: Path) -> None:
+    target.write_text(
+        json.dumps(index_data, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="Pfad zum Repository-Root.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Ausgabedatei (Standard: <repo-root>/index.json).",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+    output = args.output.resolve() if args.output else repo_root / "index.json"
+
+    index_data = build_index(repo_root)
+    write_index(index_data, output)
+
+    print(f"OK: index.json erzeugt ({len(index_data['presentations'])} Präsentationen).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Provide a reproducible, Node-free central search index (`index.json`) for the static portal and ensure the committed index is kept current via CI checks.

### Description
- Add `scripts/generate_search_index.py` which discovers presentations via `**/slides.json`, reads `manifest.json` and `slides.json`, and writes a deterministic `index.json` with `schemaVersion: "1.0.0"` and per-presentation metadata and file references.
- Add `scripts/check_search_index.py` which generates a fresh index and fails (exit code 1) if the committed `index.json` differs.
- Add CI workflow `.github/workflows/repository-checks.yml` to run `python scripts/validate_repository_structure.py` and `python scripts/check_search_index.py` on `push`/`pull_request`.
- Commit initial `index.json` for the current repository content and update `README.md` and `docs/presentation-structure.md` with generation and check instructions.

### Testing
- Ran `python scripts/generate_search_index.py` and it succeeded and produced `index.json` ("OK: index.json erzeugt (12 Präsentationen).").
- Ran `python scripts/validate_repository_structure.py` and it succeeded ("OK: 12 Präsentationen erfolgreich validiert.").
- Ran `python scripts/check_search_index.py` and it succeeded ("OK: index.json ist aktuell.").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea785495c8832aa2a5d50c5fde57de)