### PR TITLE
Portal-Startseite: Präsentationsliste (Story B1)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Foile Pile – Präsentationsportal</title>
+    <link rel="stylesheet" href="portal.css" />
+  </head>
+  <body>
+    <header class="page-header">
+      <h1>Foile Pile</h1>
+      <p class="subtitle">Übersicht aller verfügbaren Präsentationen</p>
+    </header>
+
+    <main class="content" aria-live="polite">
+      <section class="toolbar" aria-label="Sortierung">
+        <label for="sort-select">Sortierung</label>
+        <select id="sort-select" name="sort">
+          <option value="relevance">Relevanz</option>
+          <option value="alphabet">Alphabetisch (A–Z)</option>
+        </select>
+      </section>
+
+      <p id="status-message" class="status-message" hidden></p>
+
+      <ul id="presentation-list" class="presentation-list" hidden></ul>
+    </main>
+
+    <script src="portal.js" defer></script>
+  </body>
+</html>

--- a/portal.css
+++ b/portal.css
@@ -1,0 +1,109 @@
+:root {
+  color-scheme: light;
+  --bg: #f8fafc;
+  --card-bg: #ffffff;
+  --text: #0f172a;
+  --muted: #475569;
+  --accent: #0f766e;
+  --border: #cbd5e1;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.page-header,
+.content {
+  width: min(100%, 980px);
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.page-header h1 {
+  margin-bottom: 0.25rem;
+}
+
+.subtitle {
+  margin-top: 0;
+  color: var(--muted);
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.toolbar select {
+  padding: 0.4rem;
+}
+
+.status-message {
+  padding: 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 0.4rem;
+  background: #fff;
+  color: var(--muted);
+}
+
+.presentation-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.presentation-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 0.6rem;
+  padding: 1rem;
+}
+
+.presentation-card h2 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  font-size: 1.2rem;
+}
+
+.presentation-meta {
+  margin: 0.5rem 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.75rem;
+}
+
+.tag {
+  display: inline-block;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  font-size: 0.85rem;
+  color: #334155;
+  background: #f1f5f9;
+}
+
+.viewer-link {
+  color: var(--accent);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.viewer-link:hover {
+  text-decoration: underline;
+}

--- a/portal.js
+++ b/portal.js
@@ -1,0 +1,101 @@
+const INDEX_URL = "index.json";
+
+const sortSelect = document.getElementById("sort-select");
+const listElement = document.getElementById("presentation-list");
+const statusElement = document.getElementById("status-message");
+
+let loadedPresentations = [];
+
+function showStatus(message) {
+  statusElement.textContent = message;
+  statusElement.hidden = false;
+  listElement.hidden = true;
+}
+
+function clearStatus() {
+  statusElement.hidden = true;
+}
+
+function extractCategory(path) {
+  if (typeof path !== "string" || !path.trim()) {
+    return "Unbekannter Bereich";
+  }
+
+  const [category] = path.split("/");
+  return category || "Unbekannter Bereich";
+}
+
+function renderTags(tags) {
+  if (!Array.isArray(tags) || tags.length === 0) {
+    return '<span class="tag">Keine Tags</span>';
+  }
+
+  return tags.map((tag) => `<span class="tag">${tag}</span>`).join("");
+}
+
+function renderList(presentations) {
+  if (!Array.isArray(presentations) || presentations.length === 0) {
+    showStatus("Aktuell sind keine Präsentationen verfügbar.");
+    return;
+  }
+
+  clearStatus();
+
+  listElement.innerHTML = presentations
+    .map((presentation) => {
+      const title = presentation.title || "Ohne Titel";
+      const description = presentation.description || "Keine Kurzbeschreibung vorhanden.";
+      const category = extractCategory(presentation.path);
+      const viewerPath = presentation.files?.viewer || "#";
+
+      return `
+        <li class="presentation-card">
+          <h2><a class="viewer-link" href="${viewerPath}">${title}</a></h2>
+          <p>${description}</p>
+          <p class="presentation-meta">Bereich/Kategorie: <strong>${category}</strong></p>
+          <div class="tags">${renderTags(presentation.tags)}</div>
+        </li>
+      `;
+    })
+    .join("");
+
+  listElement.hidden = false;
+}
+
+function sortPresentations(presentations, mode) {
+  const copy = [...presentations];
+
+  if (mode === "alphabet") {
+    copy.sort((a, b) => (a.title || "").localeCompare(b.title || "", "de"));
+    return copy;
+  }
+
+  return copy;
+}
+
+function updateList() {
+  const selectedSort = sortSelect.value;
+  const sorted = sortPresentations(loadedPresentations, selectedSort);
+  renderList(sorted);
+}
+
+async function loadPresentations() {
+  showStatus("Präsentationen werden geladen …");
+
+  try {
+    const response = await fetch(INDEX_URL);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    const data = await response.json();
+    loadedPresentations = Array.isArray(data.presentations) ? data.presentations : [];
+    updateList();
+  } catch (error) {
+    console.error(error);
+    showStatus("Die Präsentationen konnten nicht geladen werden. Bitte versuchen Sie es später erneut.");
+  }
+}
+
+sortSelect.addEventListener("change", updateList);
+loadPresentations();


### PR DESCRIPTION
### Motivation
- Eine statische Startseite bereitstellen, mit der Benutzer Präsentationen durchsuchen und öffnen können, ohne Node.js zur Laufzeit zu benötigen.
- Metadaten aus dem bereits vorhandenen zentralen Index `index.json` sichtbar machen und einfache Sortier-/Statusfunktionen anbieten.

### Description
- Neue Datei `index.html` als statische Portal-Startseite mit Header, Sortier-Auswahl und Bereich für Statusmeldungen und Ergebnisliste hinzugefügt.
- Neue Datei `portal.js` implementiert das Laden von `index.json` per `fetch`, rendert Präsentations-Karten mit Titel, Kurzbeschreibung, Tags und Bereich (Kategorie), unterstützt Sortierung nach Relevanz bzw. Alphabet und zeigt Lade-/Leer-/Fehlerzustände an.
- Neue Datei `portal.css` enthält Basis-Styling (Layout, Karten, Tags, Statusmeldungen) und CSS-Variablen für konsistente Farbgebung.
- Kleine Zugänglichkeitsmaßnahme: das `main`-Element verwendet `aria-live="polite"` und Viewer-Links verweisen auf die in den Index-Einträgen referenzierten Viewer-Pfade.

### Testing
- `python scripts/validate_repository_structure.py` wurde ausgeführt und meldete `OK: 12 Präsentationen erfolgreich validiert.`.
- `python scripts/check_search_index.py` wurde ausgeführt und meldete `OK: index.json ist aktuell.`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea7a1d40c4832a8a805f6ad7eac923)