### PR TITLE
Implement Story B2: browser full-text search

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,14 +13,28 @@
     </header>
 
     <main class="content" aria-live="polite">
-      <section class="toolbar" aria-label="Sortierung">
-        <label for="sort-select">Sortierung</label>
-        <select id="sort-select" name="sort">
-          <option value="relevance">Relevanz</option>
-          <option value="alphabet">Alphabetisch (A–Z)</option>
-        </select>
+      <section class="toolbar" aria-label="Suche und Sortierung">
+        <label class="toolbar-field" for="search-input">
+          <span>Suche</span>
+          <input
+            id="search-input"
+            name="search"
+            type="search"
+            placeholder="Titel, Tags oder Beschreibung durchsuchen …"
+            autocomplete="off"
+          />
+        </label>
+
+        <label class="toolbar-field toolbar-field--sort" for="sort-select">
+          <span>Sortierung</span>
+          <select id="sort-select" name="sort">
+            <option value="relevance">Relevanz</option>
+            <option value="alphabet">Alphabetisch (A–Z)</option>
+          </select>
+        </label>
       </section>
 
+      <p id="result-summary" class="result-summary" hidden></p>
       <p id="status-message" class="status-message" hidden></p>
 
       <ul id="presentation-list" class="presentation-list" hidden></ul>

--- a/portal.css
+++ b/portal.css
@@ -36,14 +36,35 @@ body {
 }
 
 .toolbar {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.75rem 1rem;
   margin-bottom: 1rem;
 }
 
+.toolbar-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.toolbar input,
 .toolbar select {
   padding: 0.4rem;
+  border: 1px solid var(--border);
+  border-radius: 0.4rem;
+  background: #fff;
+}
+
+.toolbar input:focus,
+.toolbar select:focus {
+  outline: 2px solid #14b8a6;
+  outline-offset: 1px;
+}
+
+.result-summary {
+  margin: 0 0 0.75rem 0;
+  color: var(--muted);
 }
 
 .status-message {
@@ -73,6 +94,10 @@ body {
   margin-top: 0;
   margin-bottom: 0.5rem;
   font-size: 1.2rem;
+}
+
+.presentation-card p {
+  margin: 0.35rem 0;
 }
 
 .presentation-meta {
@@ -106,4 +131,20 @@ body {
 
 .viewer-link:hover {
   text-decoration: underline;
+}
+
+.search-highlight {
+  background: #fef08a;
+  padding: 0 0.15rem;
+  border-radius: 0.15rem;
+}
+
+@media (max-width: 720px) {
+  .toolbar {
+    grid-template-columns: 1fr;
+  }
+
+  .toolbar-field--sort {
+    max-width: 260px;
+  }
 }

--- a/portal.js
+++ b/portal.js
@@ -1,14 +1,20 @@
 const INDEX_URL = "index.json";
+const SEARCH_DEBOUNCE_MS = 120;
 
 const sortSelect = document.getElementById("sort-select");
+const searchInput = document.getElementById("search-input");
 const listElement = document.getElementById("presentation-list");
 const statusElement = document.getElementById("status-message");
+const resultSummaryElement = document.getElementById("result-summary");
 
 let loadedPresentations = [];
+let debounceTimerId = null;
+const searchCache = new Map();
 
 function showStatus(message) {
   statusElement.textContent = message;
   statusElement.hidden = false;
+  resultSummaryElement.hidden = true;
   listElement.hidden = true;
 }
 
@@ -25,17 +31,59 @@ function extractCategory(path) {
   return category || "Unbekannter Bereich";
 }
 
-function renderTags(tags) {
+function escapeHtml(text) {
+  return String(text)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+function normalizeText(value) {
+  return String(value || "")
+    .toLocaleLowerCase("de")
+    .normalize("NFKD")
+    .replace(/\p{Diacritic}/gu, "")
+    .replace(/ß/g, "ss")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function tokenizeQuery(rawQuery) {
+  return normalizeText(rawQuery)
+    .split(/[^\p{L}\p{N}]+/u)
+    .map((token) => token.trim())
+    .filter(Boolean);
+}
+
+function highlightMatches(text, tokens) {
+  const escaped = escapeHtml(text);
+  if (!tokens.length) {
+    return escaped;
+  }
+
+  return tokens.reduce((current, token) => {
+    if (!token) {
+      return current;
+    }
+
+    const matcher = new RegExp(`(${token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`, "giu");
+    return current.replace(matcher, '<mark class="search-highlight">$1</mark>');
+  }, escaped);
+}
+
+function renderTags(tags, queryTokens) {
   if (!Array.isArray(tags) || tags.length === 0) {
     return '<span class="tag">Keine Tags</span>';
   }
 
-  return tags.map((tag) => `<span class="tag">${tag}</span>`).join("");
+  return tags.map((tag) => `<span class="tag">${highlightMatches(tag, queryTokens)}</span>`).join("");
 }
 
-function renderList(presentations) {
+function renderList(presentations, queryTokens) {
   if (!Array.isArray(presentations) || presentations.length === 0) {
-    showStatus("Aktuell sind keine Präsentationen verfügbar.");
+    showStatus("Keine Treffer. Bitte passen Sie Ihre Suche an.");
     return;
   }
 
@@ -50,10 +98,10 @@ function renderList(presentations) {
 
       return `
         <li class="presentation-card">
-          <h2><a class="viewer-link" href="${viewerPath}">${title}</a></h2>
-          <p>${description}</p>
-          <p class="presentation-meta">Bereich/Kategorie: <strong>${category}</strong></p>
-          <div class="tags">${renderTags(presentation.tags)}</div>
+          <h2><a class="viewer-link" href="${viewerPath}">${highlightMatches(title, queryTokens)}</a></h2>
+          <p>${highlightMatches(description, queryTokens)}</p>
+          <p class="presentation-meta">Bereich/Kategorie: <strong>${highlightMatches(category, queryTokens)}</strong></p>
+          <div class="tags">${renderTags(presentation.tags, queryTokens)}</div>
         </li>
       `;
     })
@@ -73,10 +121,52 @@ function sortPresentations(presentations, mode) {
   return copy;
 }
 
+function updateSummary(resultCount, query) {
+  if (!query) {
+    resultSummaryElement.textContent = `${resultCount} Präsentationen verfügbar.`;
+    resultSummaryElement.hidden = false;
+    return;
+  }
+
+  resultSummaryElement.textContent = `${resultCount} Treffer für „${query}“.`;
+  resultSummaryElement.hidden = false;
+}
+
+function filterPresentations(queryTokens) {
+  if (!queryTokens.length) {
+    return loadedPresentations;
+  }
+
+  const cacheKey = queryTokens.join("|");
+  if (searchCache.has(cacheKey)) {
+    return searchCache.get(cacheKey);
+  }
+
+  const filtered = loadedPresentations.filter((presentation) => {
+    const haystack = normalizeText(
+      presentation.searchText ||
+        `${presentation.title || ""} ${presentation.description || ""} ${(presentation.tags || []).join(" ")}`
+    );
+    return queryTokens.every((token) => haystack.includes(token));
+  });
+
+  searchCache.set(cacheKey, filtered);
+  return filtered;
+}
+
 function updateList() {
   const selectedSort = sortSelect.value;
-  const sorted = sortPresentations(loadedPresentations, selectedSort);
-  renderList(sorted);
+  const rawQuery = searchInput.value.trim();
+  const queryTokens = tokenizeQuery(rawQuery);
+  const filtered = filterPresentations(queryTokens);
+  const sorted = sortPresentations(filtered, selectedSort);
+  updateSummary(sorted.length, rawQuery);
+  renderList(sorted, queryTokens);
+}
+
+function onSearchInput() {
+  window.clearTimeout(debounceTimerId);
+  debounceTimerId = window.setTimeout(updateList, SEARCH_DEBOUNCE_MS);
 }
 
 async function loadPresentations() {
@@ -90,6 +180,7 @@ async function loadPresentations() {
 
     const data = await response.json();
     loadedPresentations = Array.isArray(data.presentations) ? data.presentations : [];
+    searchCache.clear();
     updateList();
   } catch (error) {
     console.error(error);
@@ -98,4 +189,5 @@ async function loadPresentations() {
 }
 
 sortSelect.addEventListener("change", updateList);
+searchInput.addEventListener("input", onSearchInput);
 loadPresentations();


### PR DESCRIPTION
### Motivation
- Implement a client-side full-text search for the portal so users can quickly find presentations by title, tags or description as requested in Story B2.
- Keep the existing sorting UX while enabling fast, offline-capable search over the prebuilt `index.json`.

### Description
- Add a search input and a result summary area to the portal toolbar in `index.html` to allow querying and show hit counts.
- Update `portal.css` to provide responsive toolbar layout, input focus styles, result summary styling and a visual highlight style for matches.
- Replace the previous portal logic with `portal.js` implementing debounced searching, tokenization and normalization (lowercase, diacritics removal, `ß`→`ss`), per-query caching, filtering over `searchText`/title/description/tags and match highlighting in title/description/category/tags.
- Preserve and integrate existing sorting behavior so search results can still be ordered by relevance or alphabetically.

### Testing
- Ran `python3 scripts/check_search_index.py` and it returned OK indicating `index.json` is up to date.
- Ran `python3 scripts/validate_repository_structure.py` and it returned OK indicating presentations validate successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea7b53d280832aad2f28dbb2eccec5)