### PR TITLE
C1: Ergebnis-Karten „Ansehen“-Aktion und Viewer-Integrationsvertrag

### DIFF
--- a/portal.css
+++ b/portal.css
@@ -186,6 +186,10 @@ body {
   margin-top: 0.75rem;
 }
 
+.presentation-actions {
+  margin-top: 0.85rem;
+}
+
 .tag {
   display: inline-block;
   padding: 0.2rem 0.5rem;
@@ -196,6 +200,32 @@ body {
   background: #f1f5f9;
 }
 
+.view-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.45rem 0.75rem;
+  border-radius: 0.45rem;
+  border: 1px solid #0f766e;
+  background: #0f766e;
+  color: #ecfeff;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.view-action:hover {
+  background: #0d5f59;
+  border-color: #0d5f59;
+}
+
+.view-action--disabled {
+  border-color: #94a3b8;
+  background: #cbd5e1;
+  color: #334155;
+  cursor: not-allowed;
+}
+
 .viewer-link {
   color: var(--accent);
   font-weight: 600;
@@ -204,6 +234,13 @@ body {
 
 .viewer-link:hover {
   text-decoration: underline;
+}
+
+.viewer-error {
+  margin-top: 0.6rem;
+  margin-bottom: 0;
+  color: #b91c1c;
+  font-size: 0.92rem;
 }
 
 .search-highlight {

--- a/portal.js
+++ b/portal.js
@@ -1,5 +1,7 @@
 const INDEX_URL = "index.json";
 const SEARCH_DEBOUNCE_MS = 120;
+const SLIDES_FILE_NAME = "slides.json";
+const VIEWER_BASE_URL = "https://huluvu424242.github.io/sld-slideshow-viewer/";
 
 const sortSelect = document.getElementById("sort-select");
 const searchInput = document.getElementById("search-input");
@@ -105,6 +107,41 @@ function renderTags(tags, queryTokens) {
   return tags.map((tag) => `<span class="tag">${highlightMatches(tag, queryTokens)}</span>`).join("");
 }
 
+function buildViewerContract(presentation) {
+  const files = presentation?.files;
+  if (!files || typeof files !== "object") {
+    return { isValid: false, reason: "Fehlende Dateiliste im Suchindex." };
+  }
+
+  const slidesPath = typeof files.slides === "string" ? files.slides.trim() : "";
+  if (!slidesPath) {
+    return { isValid: false, reason: "Fehlende Foliendatei (slides.json)." };
+  }
+  if (!slidesPath.endsWith(SLIDES_FILE_NAME)) {
+    return { isValid: false, reason: "Ungültige Foliendatei im Suchindex." };
+  }
+
+  const manifestPath = typeof files.manifest === "string" ? files.manifest.trim() : "";
+  if (!manifestPath || !manifestPath.endsWith("manifest.json")) {
+    return { isValid: false, reason: "Ungültiges oder fehlendes Manifest im Suchindex." };
+  }
+
+  try {
+    const slidesUrl = new URL(slidesPath, window.location.href).href;
+    const viewerUrl = new URL(VIEWER_BASE_URL);
+    viewerUrl.searchParams.set("url", slidesUrl);
+
+    return {
+      isValid: true,
+      viewerHref: viewerUrl.href,
+      slidesUrl,
+      manifestUrl: new URL(manifestPath, window.location.href).href,
+    };
+  } catch (_error) {
+    return { isValid: false, reason: "Ungültiger Dateipfad im Suchindex." };
+  }
+}
+
 function renderList(presentations, queryTokens) {
   if (!Array.isArray(presentations) || presentations.length === 0) {
     showStatus("Keine Treffer. Bitte passen Sie Ihre Suche an.");
@@ -118,14 +155,40 @@ function renderList(presentations, queryTokens) {
       const title = presentation.title || "Ohne Titel";
       const description = presentation.description || "Keine Kurzbeschreibung vorhanden.";
       const category = extractCategory(presentation.path);
-      const viewerPath = presentation.files?.viewer || "#";
+      const viewerContract = buildViewerContract(presentation);
+      const viewAction = viewerContract.isValid
+        ? `
+          <a
+            class="view-action"
+            href="${escapeHtml(viewerContract.viewerHref)}"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="${escapeHtml(title)} im Viewer ansehen"
+            data-slides-url="${escapeHtml(viewerContract.slidesUrl)}"
+            data-manifest-url="${escapeHtml(viewerContract.manifestUrl)}"
+          >
+            Ansehen
+          </a>
+        `
+        : `
+          <button class="view-action view-action--disabled" type="button" disabled aria-disabled="true">
+            Ansehen nicht verfügbar
+          </button>
+        `;
+      const viewError = viewerContract.isValid
+        ? ""
+        : `<p class="viewer-error" role="status">${escapeHtml(viewerContract.reason)}</p>`;
 
       return `
         <li class="presentation-card">
-          <h2><a class="viewer-link" href="${viewerPath}">${highlightMatches(title, queryTokens)}</a></h2>
+          <h2>${highlightMatches(title, queryTokens)}</h2>
           <p>${highlightMatches(description, queryTokens)}</p>
           <p class="presentation-meta">Bereich/Kategorie: <strong>${highlightMatches(category, queryTokens)}</strong></p>
           <div class="tags">${renderTags(presentation.tags, queryTokens)}</div>
+          <div class="presentation-actions">
+            ${viewAction}
+          </div>
+          ${viewError}
         </li>
       `;
     })


### PR DESCRIPTION
### Motivation
- Nutzer sollen einzelne Präsentationen direkt aus der Ergebnisliste im externen Slideshow-Viewer öffnen können.  
- Die Launch-URL muss aus dem statischen Suchindex sicher und robust erzeugt werden.  
- Fehlende oder fehlerhafte Indexdaten sollen sichtbar und handhabbar gemacht werden.

### Description
- Implementiert eine Viewer-Integrationsschicht in `portal.js` durch die Konstante `VIEWER_BASE_URL` und `SLIDES_FILE_NAME` sowie die Funktion `buildViewerContract` zur Validierung und Erzeugung der Viewer-URL.  
- Erweitert die Karten-Rendering-Logik in `renderList` so dass jede Karte jetzt eine dedizierte Aktion rendert: aktive Links (`<a class="view-action">`) öffnen den Viewer mit `?url=<absolute slides.json>` oder alternativ eine deaktivierte Schaltfläche plus Fehlermeldung bei ungültigen Daten.  
- Fügt UI-Styles in `portal.css` für die neue Aktion, Disabled-State und Inline-Fehlermeldungen (`.view-action`, `.view-action--disabled`, `.viewer-error`, `.presentation-actions`) hinzu.  
- Behandelt verschiedene Fehlerfälle explizit (fehlende `files`, fehlende/ungültige `slides.json`, fehlendes/ungültiges `manifest.json`, fehlerhafte Pfadauflösung) und zeigt entsprechende, nutzerfreundliche Hinweise auf der Karte an.

### Testing
- `python scripts/check_search_index.py` wurde ausgeführt und meldete `OK` für den Index.  
- `python scripts/validate_repository_structure.py` wurde ausgeführt und meldete `OK` für die Repository-Struktur.  
- Ein kleiner Smoke-Test (Erzeugung der Viewer-URL für reale Einträge aus `index.json`) wurde ausgeführt und validierte die URL-Generierung für mehrere Präsentationen erfolgreich.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea7f4ed198832a9af158c34db8ba02)