### PR TITLE
docs: add node-free developer and release workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,19 @@ Als Nutzer möchte ich in einem Webportal Präsentationen finden, ansehen und al
 
 ## Repository-Konventionen
 - Standardisierte Präsentationsstruktur: `docs/presentation-structure.md`
+- Entwickler-Workflow ohne Node.js: `docs/developer-workflow.md`
 - Validierungsskript: `python scripts/validate_repository_structure.py`
 
 - Zentralen Suchindex erzeugen: `python scripts/generate_search_index.py`
 - Suchindex auf Aktualität prüfen: `python scripts/check_search_index.py`
 
+## Quickstart (ohne Node.js)
+
+```bash
+python3 scripts/validate_repository_structure.py
+python3 scripts/generate_search_index.py
+python3 scripts/check_search_index.py
+python3 -m http.server 8080
+```
+
+Danach ist das Portal lokal unter <http://localhost:8080/> erreichbar.

--- a/docs/developer-workflow.md
+++ b/docs/developer-workflow.md
@@ -1,0 +1,82 @@
+# Entwickler-Workflow ohne Node.js
+
+Dieser Workflow beschreibt lokale Entwicklung, Qualitätschecks und einen einfachen Release-Ablauf **ohne npm/node**.
+
+## Voraussetzungen
+
+- Git
+- Python 3.10+ (inkl. Standardbibliothek)
+- Bash (Linux/macOS) oder Git Bash (Windows)
+
+## Quickstart (sauberes System)
+
+```bash
+git clone https://github.com/Huluvu424242/foile-pile.git
+cd foile-pile
+python3 scripts/validate_repository_structure.py
+python3 scripts/generate_search_index.py
+python3 scripts/check_search_index.py
+python3 -m http.server 8080
+```
+
+Danach ist das Portal lokal verfügbar unter:
+
+- <http://localhost:8080/>
+
+## Lokale Entwicklung
+
+1. Änderungen an Präsentationen, Metadaten oder Portal-Dateien durchführen.
+2. Struktur validieren:
+
+   ```bash
+   python3 scripts/validate_repository_structure.py
+   ```
+
+3. Suchindex neu erzeugen:
+
+   ```bash
+   python3 scripts/generate_search_index.py
+   ```
+
+4. Konsistenz prüfen:
+
+   ```bash
+   python3 scripts/check_search_index.py
+   ```
+
+5. Änderungen committen:
+
+   ```bash
+   git add .
+   git commit -m "Beschreibe die Änderung"
+   ```
+
+## Release-Workflow (statische Auslieferung)
+
+Der Release benötigt nur Git + Python und erzeugt ein statisch auslieferbares Repository.
+
+```bash
+# 1) Arbeitsstand aktualisieren
+git checkout main
+git pull --ff-only
+
+# 2) Qualitätschecks
+python3 scripts/validate_repository_structure.py
+python3 scripts/generate_search_index.py
+python3 scripts/check_search_index.py
+
+# 3) Release committen (falls index.json aktualisiert wurde)
+git add index.json
+git commit -m "chore: update search index"
+
+# 4) Veröffentlichen
+git push origin main
+```
+
+## Troubleshooting
+
+- `python3: command not found`  
+  -> Python 3 installieren und erneut ausführen.
+
+- `FEHLER: index.json ist nicht aktuell.`  
+  -> `python3 scripts/generate_search_index.py` ausführen und Änderungen committen.


### PR DESCRIPTION
### Motivation
- Provide a clear developer and release workflow that requires no Node.js/npm so the project can be developed and released on systems with only Git/Python/Bash (implements issue #13 intent).
- Make it trivial to validate repository structure, regenerate the central search index and run the portal locally using only standard Python tooling.

### Description
- Add `docs/developer-workflow.md` containing prerequisites, quickstart, local development steps, release flow and troubleshooting using `git`/`python3`/`bash` only. 
- Update `README.md` to reference the new workflow document and add a concise `Quickstart (ohne Node.js)` section with the typical commands `python3 scripts/validate_repository_structure.py`, `python3 scripts/generate_search_index.py`, `python3 scripts/check_search_index.py` and `python3 -m http.server 8080`.
- Ensure the quickstart instructs how to run the portal locally at `http://localhost:8080/`.

### Testing
- Ran `python3 scripts/validate_repository_structure.py` which returned: `OK: 12 Präsentationen erfolgreich validiert.`
- Ran `python3 scripts/generate_search_index.py` which returned: `OK: index.json erzeugt (12 Präsentationen).`
- Ran `python3 scripts/check_search_index.py` which returned: `OK: index.json ist aktuell.`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea86763efc832ab2fde84c0a51caf4)