### PR TITLE
docs: add static hosting deployment guide with cache strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Als Nutzer möchte ich in einem Webportal Präsentationen finden, ansehen und al
 ## Repository-Konventionen
 - Standardisierte Präsentationsstruktur: `docs/presentation-structure.md`
 - Entwickler-Workflow ohne Node.js: `docs/developer-workflow.md`
+- Deployment-Anleitung für statisches Hosting: `docs/deployment-static-hosting.md`
 - Validierungsskript: `python scripts/validate_repository_structure.py`
 
 - Zentralen Suchindex erzeugen: `python scripts/generate_search_index.py`

--- a/docs/deployment-static-hosting.md
+++ b/docs/deployment-static-hosting.md
@@ -1,0 +1,85 @@
+# Deployment als statische Seite
+
+Diese Anleitung beschreibt den Betrieb des Portals **ohne Node.js** auf einem statischen Host.
+
+## Ziel
+
+Die Anwendung wird ausschließlich als statische Dateien ausgeliefert:
+
+- `index.html`
+- `portal.css`
+- `portal.js`
+- `index.json`
+- Präsentationsordner unter `guides/`, `explainations/`, `evaluationen/`, `projects/`
+
+Es ist **kein Build-System** notwendig. Der veröffentlichte Git-Stand ist direkt das Deployment-Artefakt.
+
+## Beispiel-Zielsystem: GitHub Pages
+
+1. Repository auf `main` aktuell halten.
+2. Vor Veröffentlichung lokale Checks ausführen:
+
+   ```bash
+   python3 scripts/validate_repository_structure.py
+   python3 scripts/generate_search_index.py
+   python3 scripts/check_search_index.py
+   ```
+
+3. Änderungen committen und pushen:
+
+   ```bash
+   git add .
+   git commit -m "chore: release static site"
+   git push origin main
+   ```
+
+4. In GitHub unter **Settings → Pages** als Source `Deploy from a branch` wählen und Branch `main` / Folder `/ (root)` konfigurieren.
+
+Danach wird das Portal als statische Seite ausgeliefert.
+
+## Cache-Strategie
+
+Damit Nutzer zeitnah neue Inhalte sehen und gleichzeitig gute Ladezeiten erhalten, werden zwei Klassen unterschieden.
+
+### 1) `index.json` (häufige Inhaltsänderungen)
+
+Empfohlene HTTP-Header:
+
+- `Cache-Control: no-cache, must-revalidate`
+- Optional: `ETag` oder `Last-Modified`
+
+Wirkung:
+
+- Browser dürfen cachen, müssen aber vor Wiederverwendung revalidieren.
+- Aktualisierte Suchindizes werden schnell sichtbar.
+
+### 2) Statische Assets (`portal.css`, `portal.js`, Bilder, Präsentationsdateien)
+
+Empfohlene HTTP-Header:
+
+- `Cache-Control: public, max-age=31536000, immutable`
+
+Wirkung:
+
+- Sehr lange Browser-Caches für selten geänderte Dateien.
+- Geringere Ladezeiten und weniger Bandbreite.
+
+### Versionierung bei Änderungen
+
+Bei geänderten Assets sollte ein Versionsparameter oder Dateinamenswechsel verwendet werden, damit Clients neue Dateien laden.
+
+Beispiel in `index.html`:
+
+```html
+<link rel="stylesheet" href="portal.css?v=2026-04-23">
+<script src="portal.js?v=2026-04-23" defer></script>
+```
+
+Für `index.json` kann ebenfalls ein Versionsparameter gesetzt werden (z. B. `index.json?v=2026-04-23`), falls ein Host keine Header-Steuerung erlaubt.
+
+## Verifikation nach Deployment
+
+- Startseite lädt ohne JavaScript-Fehler.
+- Präsentationsliste wird aus `index.json` angezeigt.
+- Suche/Filter funktionieren im Browser.
+- Viewer- und Download-Links funktionieren relativ (ohne host-spezifische absolute URLs).


### PR DESCRIPTION
### Motivation
- Provide a clear deployment recipe for the portal to run as a purely static site without Node.js, matching the repository's goal to be hostable on GitHub Pages/Nginx/S3.
- Document a practical cache strategy so updates to `index.json` and long-lived assets behave predictably for clients.
- Surface the deployment guidance in the repository conventions so maintainers discover the steps as part of normal workflows.

### Description
- Add `docs/deployment-static-hosting.md` containing instructions for deploying the site as static files, an example target (GitHub Pages), release steps without Node.js, a cache-control strategy and a post-deploy verification checklist.
- Update `README.md` to reference the new `docs/deployment-static-hosting.md` from the repository conventions section.
- Recommend HTTP header values for `index.json` and static assets and include a versioning pattern for asset URLs to force client refresh when needed.
- No runtime code changes were made; this PR is documentation-only and keeps the static-site workflow unchanged.

### Testing
- Ran `python3 scripts/validate_repository_structure.py` and it completed successfully (validated 12 presentations).
- Ran `python3 scripts/generate_search_index.py` which produced `index.json` successfully.
- Ran `python3 scripts/check_search_index.py` and it reported `index.json` is up to date.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea87fd79a8832aa225b9bcbb7fef49)