### PR TITLE
Exclude .extra folder and manifest from export and checksum validation

### DIFF
--- a/portal.js
+++ b/portal.js
@@ -3,6 +3,7 @@ const SEARCH_DEBOUNCE_MS = 120;
 const SLIDES_FILE_NAME = "slides.json";
 const MANIFEST_FILE_NAME = "manifest.json";
 const VIEWER_BASE_URL = "https://huluvu424242.github.io/sld-slideshow-viewer/";
+const EXTRA_FOLDER_NAME = ".extra";
 
 const sortSelect = document.getElementById("sort-select");
 const searchInput = document.getElementById("search-input");
@@ -217,6 +218,16 @@ function normalizeRelativePath(path, basePath) {
   return normalized.startsWith(basePath) ? normalized : null;
 }
 
+function isPathExcludedFromExport(path, basePath) {
+  const prefix = `${basePath}/`;
+  if (typeof path !== "string" || !path.startsWith(prefix)) {
+    return false;
+  }
+
+  const relativePath = path.slice(prefix.length);
+  return relativePath.split("/").includes(EXTRA_FOLDER_NAME);
+}
+
 function collectSlideReferences(slidesData, basePath) {
   const refs = new Set();
   const slides = Array.isArray(slidesData?.slides) ? slidesData.slides : [];
@@ -294,19 +305,20 @@ async function createPresentationZip(downloadContract, presentation) {
   const slides = await fetchJson(downloadContract.slidesUrl, "Slides laden fehlgeschlagen");
   const basePath = downloadContract.basePath;
 
-  const fileSet = new Set([
-    `${basePath}/${MANIFEST_FILE_NAME}`,
-    `${basePath}/${SLIDES_FILE_NAME}`,
-  ]);
+  const fileSet = new Set([`${basePath}/${SLIDES_FILE_NAME}`]);
 
   [presentation.files?.fulltext, presentation.files?.tags, presentation.files?.viewer].forEach((path) => {
     const normalized = normalizeRelativePath(path, basePath);
-    if (normalized) {
+    if (normalized && !isPathExcludedFromExport(normalized, basePath)) {
       fileSet.add(normalized);
     }
   });
 
-  collectSlideReferences(slides, basePath).forEach((path) => fileSet.add(path));
+  collectSlideReferences(slides, basePath).forEach((path) => {
+    if (!isPathExcludedFromExport(path, basePath)) {
+      fileSet.add(path);
+    }
+  });
 
   const files = [];
   const missingFiles = [];
@@ -341,6 +353,10 @@ async function createPresentationZip(downloadContract, presentation) {
     const fileMap = new Map(files.map((file) => [file.path, file.data]));
     const checksumIssues = [];
     for (const [path, expected] of checksums.entries()) {
+      if (path === `${basePath}/${MANIFEST_FILE_NAME}` || isPathExcludedFromExport(path, basePath)) {
+        continue;
+      }
+
       const fileData = fileMap.get(path);
       if (!fileData) {
         checksumIssues.push(`${path} (Prüfsumme vorhanden, Datei fehlt)`);


### PR DESCRIPTION
### Motivation
- Prevent internal or auxiliary files stored under a `.extra` folder from being included in exported presentation zips and from affecting checksum validation.
- Avoid treating the top-level manifest file as a regular exportable file to keep it out of packaging and checksum comparisons.

### Description
- Introduced `EXTRA_FOLDER_NAME` and a helper `isPathExcludedFromExport(path, basePath)` to detect files inside the `.extra` folder.
- Updated `createPresentationZip` to no longer unconditionally include the manifest file and to skip any paths that are inside the `.extra` folder when adding presentation-related files and slide references.
- Modified checksum validation to skip the manifest and any excluded paths when checking expected checksums against fetched files.
- Kept slide reference collection logic intact and only filtered those references through the new exclusion helper before adding to the zip file list.

### Testing
- Ran the existing automated test suite and linters via `npm test` and static checks, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebe58dfa94832a97edfbbbfd6c9d1c)