### PR TITLE
feat: sync manifests workflow and regenerate index.json

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,4 +1,4 @@
-name: Sync Manifests
+name: Sync
 
 on:
   workflow_dispatch:
@@ -10,7 +10,7 @@ permissions:
   contents: write
 
 jobs:
-  sync-manifests:
+  sync:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -23,14 +23,14 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Generate or update all manifests
+      - name: Generate or update all manifests and index
         run: python scripts/sync_manifests.py
 
       - name: Ensure manifests are up to date in pull requests
         if: github.event_name == 'pull_request'
         run: |
           if ! git diff --quiet; then
-            echo "Die Manifest-Dateien sind nicht aktuell."
+            echo "Manifest- oder Index-Dateien sind nicht aktuell."
             echo "Bitte lokal ausführen: python scripts/sync_manifests.py"
             git diff
             exit 1
@@ -40,12 +40,12 @@ jobs:
         if: github.event_name != 'pull_request'
         run: |
           if git diff --quiet; then
-            echo "Keine Änderungen an manifest.json-Dateien gefunden."
+            echo "Keine Änderungen an manifest.json oder index.json gefunden."
             exit 0
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .
-          git commit -m "chore: sync generated manifests"
+          git commit -m "chore: sync generated manifests and index"
           git push

--- a/index.json
+++ b/index.json
@@ -23,10 +23,14 @@
           "evaluationen/community-tools/tools.md",
           "evaluationen/community-tools/tools.txt"
         ],
-        "fulltext": "evaluationen/community-tools/0index.txt",
         "manifest": "evaluationen/community-tools/manifest.json",
         "slides": "evaluationen/community-tools/slides.json",
-        "tags": "evaluationen/community-tools/0tags.txt",
+        "tags": [
+          "groupware",
+          "community",
+          "evaluation",
+          "tools"
+        ],
         "viewer": "evaluationen/community-tools/index.html"
       },
       "language": "de",
@@ -73,10 +77,14 @@
           "explainations/javascript/grundlagen/statischebindung.md",
           "explainations/javascript/grundlagen/statischebindung.txt"
         ],
-        "fulltext": "explainations/javascript/grundlagen/0index.txt",
         "manifest": "explainations/javascript/grundlagen/manifest.json",
         "slides": "explainations/javascript/grundlagen/slides.json",
-        "tags": "explainations/javascript/grundlagen/0tags.txt",
+        "tags": [
+          "javascript",
+          "begriffe",
+          "konzepte",
+          "grundlagen"
+        ],
         "viewer": "explainations/javascript/grundlagen/index.html"
       },
       "language": "de",
@@ -107,10 +115,13 @@
           "explainations/json/jsonschema/slide4.md",
           "explainations/json/jsonschema/slides.json"
         ],
-        "fulltext": "explainations/json/jsonschema/0index.txt",
         "manifest": "explainations/json/jsonschema/manifest.json",
         "slides": "explainations/json/jsonschema/slides.json",
-        "tags": "explainations/json/jsonschema/0tags.txt",
+        "tags": [
+          "json",
+          "schema",
+          "cdc"
+        ],
         "viewer": "explainations/json/jsonschema/index.html"
       },
       "language": "de",
@@ -146,10 +157,14 @@
           "explainations/mesh/meshnetze/manifest.json",
           "explainations/mesh/meshnetze/slides.json"
         ],
-        "fulltext": "explainations/mesh/meshnetze/0index.txt",
         "manifest": "explainations/mesh/meshnetze/manifest.json",
         "slides": "explainations/mesh/meshnetze/slides.json",
-        "tags": "explainations/mesh/meshnetze/0tags.txt",
+        "tags": [
+          "slideshow",
+          "mesh netze",
+          "mesh",
+          "grundlagen"
+        ],
         "viewer": "explainations/mesh/meshnetze/index.html"
       },
       "language": "de",
@@ -275,10 +290,14 @@
           "explainations/stenciljs/virtualdom.md",
           "explainations/stenciljs/webworker.md"
         ],
-        "fulltext": "explainations/stenciljs/0index.txt",
         "manifest": "explainations/stenciljs/manifest.json",
         "slides": "explainations/stenciljs/slides.json",
-        "tags": "explainations/stenciljs/0tags.txt",
+        "tags": [
+          "stenciljs",
+          "begriffe",
+          "konzepte",
+          "grundlagen"
+        ],
         "viewer": "explainations/stenciljs/index.html"
       },
       "language": "de",
@@ -307,10 +326,12 @@
           "explainations/test/unittest/slide2.txt",
           "explainations/test/unittest/slides.json"
         ],
-        "fulltext": "explainations/test/unittest/0index.txt",
         "manifest": "explainations/test/unittest/manifest.json",
         "slides": "explainations/test/unittest/slides.json",
-        "tags": "explainations/test/unittest/0tags.txt",
+        "tags": [
+          "test",
+          "unitest"
+        ],
         "viewer": "explainations/test/unittest/index.html"
       },
       "language": "de",
@@ -339,10 +360,15 @@
           "explainations/ux/designrules/slide3.txt",
           "explainations/ux/designrules/slides.json"
         ],
-        "fulltext": "explainations/ux/designrules/0index.txt",
         "manifest": "explainations/ux/designrules/manifest.json",
         "slides": "explainations/ux/designrules/slides.json",
-        "tags": "explainations/ux/designrules/0tags.txt",
+        "tags": [
+          "ux",
+          "design",
+          "entscheidungen",
+          "gui",
+          "regeln"
+        ],
         "viewer": "explainations/ux/designrules/index.html"
       },
       "language": "de",
@@ -381,10 +407,14 @@
           "guides/bddtesting/slide5.txt",
           "guides/bddtesting/slides.json"
         ],
-        "fulltext": "guides/bddtesting/0index.txt",
         "manifest": "guides/bddtesting/manifest.json",
         "slides": "guides/bddtesting/slides.json",
-        "tags": "guides/bddtesting/0tags.txt",
+        "tags": [
+          "bdd",
+          "cucumber",
+          "e2e",
+          "testing"
+        ],
         "viewer": "guides/bddtesting/index.html"
       },
       "language": "de",
@@ -419,10 +449,14 @@
           "guides/msys2-installation/update.md",
           "guides/msys2-installation/winpath.md"
         ],
-        "fulltext": "guides/msys2-installation/0index.txt",
         "manifest": "guides/msys2-installation/manifest.json",
         "slides": "guides/msys2-installation/slides.json",
-        "tags": "guides/msys2-installation/0tags.txt",
+        "tags": [
+          "msys2",
+          "howto",
+          "installation",
+          "configuration"
+        ],
         "viewer": "guides/msys2-installation/index.html"
       },
       "language": "de",
@@ -445,10 +479,12 @@
           "projects/foile-pile/manifest.json",
           "projects/foile-pile/slides.json"
         ],
-        "fulltext": "projects/foile-pile/0index.txt",
         "manifest": "projects/foile-pile/manifest.json",
         "slides": "projects/foile-pile/slides.json",
-        "tags": "projects/foile-pile/0tags.txt",
+        "tags": [
+          "foile",
+          "slides"
+        ],
         "viewer": "projects/foile-pile/index.html"
       },
       "language": "de",
@@ -469,10 +505,14 @@
           "projects/honey-slideshow/manifest.json",
           "projects/honey-slideshow/slides.json"
         ],
-        "fulltext": "projects/honey-slideshow/0index.txt",
         "manifest": "projects/honey-slideshow/manifest.json",
         "slides": "projects/honey-slideshow/slides.json",
-        "tags": "projects/honey-slideshow/0tags.txt",
+        "tags": [
+          "slideshow",
+          "slidecast",
+          "slides",
+          "audio"
+        ],
         "viewer": "projects/honey-slideshow/index.html"
       },
       "language": "de",
@@ -495,10 +535,15 @@
           "projects/jenkins-monitor/manifest.json",
           "projects/jenkins-monitor/slides.json"
         ],
-        "fulltext": "projects/jenkins-monitor/0index.txt",
         "manifest": "projects/jenkins-monitor/manifest.json",
         "slides": "projects/jenkins-monitor/slides.json",
-        "tags": "projects/jenkins-monitor/0tags.txt",
+        "tags": [
+          "jenkins",
+          "monitor",
+          "java",
+          "jenkinsmonitor",
+          "devops"
+        ],
         "viewer": "projects/jenkins-monitor/index.html"
       },
       "language": "de",

--- a/scripts/generate_search_index.py
+++ b/scripts/generate_search_index.py
@@ -42,12 +42,16 @@ def discover_presentations(repo_root: Path) -> list[dict[str, object]]:
             if path.is_file() and ".extra" not in path.relative_to(presentation_dir).parts
         )
 
+        tags = slides.get("tags", [])
+        if not isinstance(tags, list):
+            tags = []
+        tags = [tag for tag in tags if isinstance(tag, str) and tag.strip()]
+
         files = {
             "manifest": manifest_path.relative_to(repo_root).as_posix(),
             "slides": slides_path.relative_to(repo_root).as_posix(),
             "viewer": f"{rel_path}/index.html",
-            "tags": f"{rel_path}/0tags.txt",
-            "fulltext": f"{rel_path}/0index.txt",
+            "tags": tags,
             "export": export_files,
         }
 

--- a/scripts/sync_manifests.py
+++ b/scripts/sync_manifests.py
@@ -9,6 +9,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from generate_search_index import build_index, write_index
+
 DEFAULT_LANGUAGE = "de"
 
 
@@ -120,7 +122,13 @@ def main() -> int:
             print(f"Aktualisiert: {slides_path.parent.relative_to(repo_root).as_posix()}/manifest.json")
             changed += 1
 
+    index_path = repo_root / "index.json"
+    previous_index = index_path.read_text(encoding="utf-8") if index_path.exists() else None
+    write_index(build_index(repo_root), index_path)
+    index_changed = previous_index != index_path.read_text(encoding="utf-8")
+
     print(f"Fertig. Geänderte manifest.json: {changed}")
+    print(f"Index aktualisiert: {'ja' if index_changed else 'nein'}")
     return 0
 
 


### PR DESCRIPTION
### Motivation
- Keep the central search index (`index.json`) in sync when manifests are regenerated so the CI workflow and repository state stay consistent.
- Surface tags from `slides.json` directly in the index to make search metadata easier to consume by tools and UIs.

### Description
- Renamed and adjusted the GitHub Actions workflow file from `/.github/workflows/sync-manifests.yml` to `/.github/workflows/sync.yml` and updated job/step text to reflect manifest and index synchronization.
- Extended `scripts/sync_manifests.py` to call `build_index`/`write_index` and write `index.json` after manifest updates and to report whether the index changed.
- Updated `scripts/generate_search_index.py` to populate `files.tags` with a cleaned tag list taken from each `slides.json` and removed the `files.fulltext` entry.
- Regenerated `index.json` so presentation entries now include `files.tags` as lists and no longer include `fulltext` paths.

### Testing
- Ran `python scripts/sync_manifests.py` which completed and reported the index update status (`Index aktualisiert: ja`).
- Ran `python scripts/check_search_index.py` which printed `OK: index.json ist aktuell.` indicating the committed index matches generated output.
- Ran `python scripts/validate_repository_structure.py` which printed `OK: 12 Präsentationen erfolgreich validiert.` indicating repository structure validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebf6547ac8832a8bfbe0117f8d936b)