### PR TITLE
Fix 404 failures when downloading .sld files on GitHub Pages

### DIFF
--- a/portal.js
+++ b/portal.js
@@ -201,7 +201,11 @@ function normalizeRelativePath(path, basePath) {
   }
 
   const cleaned = path.replace(/\\/g, "/").trim();
-  const absolute = cleaned.startsWith("/") ? cleaned.slice(1) : `${basePath}/${cleaned}`;
+  const absolute = cleaned.startsWith("/")
+    ? cleaned.slice(1)
+    : cleaned.startsWith(`${basePath}/`) || cleaned === basePath
+      ? cleaned
+      : `${basePath}/${cleaned}`;
   const normalizedSegments = [];
   absolute.split("/").forEach((segment) => {
     if (!segment || segment === ".") {


### PR DESCRIPTION
### Motivation
- Beheben, dass beim Erzeugen von `.sld`-Downloads Pfade aus `index.json`, die bereits mit dem Präsentations-`basePath` beginnen, doppelt präfixiert wurden und dadurch auf GitHub Pages 404-Fehler entstanden.

### Description
- Ändere `normalizeRelativePath` in `portal.js` so dass Pfade, die bereits mit ``${basePath}/`` beginnen oder exakt `basePath` sind, unverändert übernommen werden und nur echte relative Pfade mit ``${basePath}/`` ergänzt werden.

### Testing
- Automatisierte Prüfung `node --check portal.js` lief erfolgreich; ein Versuch, das Skript in einem Node-VM-Kontext auszuführen, schlug aufgrund fehlender DOM-Mocks (z.B. `addEventListener`) fehl und beeinträchtigt nicht die korrigierte Pfadlogik.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebfae07e20832aa856fa4defaf26d1)