### PR TITLE
Fix SLD export paths to start at slides root

### DIFF
--- a/portal.js
+++ b/portal.js
@@ -269,6 +269,14 @@ function formatValidationIssues(title, issues) {
   return `${title}\n${issues.map((issue) => `- ${issue}`).join("\n")}`;
 }
 
+function resolveZipEntryPath(path, basePath) {
+  const prefix = `${basePath}/`;
+  if (typeof path !== "string" || !path.startsWith(prefix)) {
+    return path;
+  }
+  return path.slice(prefix.length);
+}
+
 function resolveChecksumEntries(manifest, basePath) {
   const source = manifest?.checksums || manifest?.integrity;
   if (!source || typeof source !== "object" || Array.isArray(source)) {
@@ -387,12 +395,13 @@ async function createPresentationZip(downloadContract, presentation) {
     }
   }
 
-  return createStoredZip(files);
+  return createStoredZip(files, basePath);
 }
 
-function createStoredZip(files) {
+function createStoredZip(files, basePath) {
   const fileRecords = files.map((file) => {
-    const nameBytes = new TextEncoder().encode(file.path);
+    const zipPath = resolveZipEntryPath(file.path, basePath);
+    const nameBytes = new TextEncoder().encode(zipPath);
     return { ...file, nameBytes, crc: crc32(file.data) };
   });
 


### PR DESCRIPTION
### Motivation
- Beim Erzeugen einer `.sld`-Datei sollten ZIP-Einträge relativ zur Präsentationswurzel (`slides.json`) liegen, damit keine Verzeichnisse oberhalb von `slides.json` im Archiv landen.

### Description
- Ergänzt `resolveZipEntryPath(path, basePath)` zur Umwandlung exportierter Pfade in ZIP-Einträge relativ zu `basePath`.
- Übergibt `basePath` an `createStoredZip(...)` und verwendet den bereinigten `zipPath` für die ZIP-Eintragserzeugung statt des vollständigen Pfads.
- Stellt sicher, dass `slides.json` im ZIP-Wurzelverzeichnis liegt und Unterverzeichnisse innerhalb der Präsentation weiterhin erhalten bleiben.

### Testing
- Automatisierte Repository-Validierung ausgeführt mit `python3 scripts/validate_repository_structure.py` und erfolgreich abgeschlossen.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebfccec38c832abb707a2318a54c2a)